### PR TITLE
Resolved all but two sorry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.lake
+/references
+/audit

--- a/DeRhamCohomology.lean
+++ b/DeRhamCohomology.lean
@@ -2,6 +2,8 @@ import DeRhamCohomology.Alternating.Basic
 import DeRhamCohomology.ContinuousAlternatingMap.Curry
 import DeRhamCohomology.ContinuousAlternatingMap.FDeriv
 import DeRhamCohomology.ContinuousAlternatingMap.Wedge
+import DeRhamCohomology.ContinuousAlternatingMap.WedgeFDeriv
+import DeRhamCohomology.ContinuousAlternatingMap.WedgeAssoc
 import DeRhamCohomology.DifferentialForm
 import DeRhamCohomology.Equiv.Fin
 import DeRhamCohomology.Fin

--- a/DeRhamCohomology/Alternating/Basic.lean
+++ b/DeRhamCohomology/Alternating/Basic.lean
@@ -21,21 +21,47 @@ variable
 def _root_.LinearIsometryEquiv.flipAlternating :
     (M' →L[𝕜] (M [⋀^ι]→L[𝕜] N)) ≃ₗᵢ[𝕜] (M [⋀^ι]→L[𝕜] (M' →L[𝕜] N)) where
   toFun := ContinuousLinearMap.flipAlternating
-  invFun f := sorry
+  invFun g := LinearMap.mkContinuous
+    { toFun := fun m' => (ContinuousLinearMap.apply 𝕜 N m').compContinuousAlternatingMap g
+      map_add' := fun m₁ m₂ => by ext v; simp
+      map_smul' := fun c m => by ext v; simp }
+    ‖g‖
+    (fun m' => by
+      refine (ContinuousLinearMap.norm_compContinuousAlternatingMap_le _ g).trans ?_
+      rw [mul_comm ‖g‖]
+      gcongr
+      exact ContinuousLinearMap.opNorm_le_bound _ (norm_nonneg m') fun fL => by
+        rw [ContinuousLinearMap.apply_apply]; exact (fL.le_opNorm m').trans_eq (mul_comm _ _))
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
-  left_inv := sorry
-  right_inv := sorry
-  norm_map' := sorry
+  left_inv f := by ext m' v; simp
+  right_inv g := by ext v m'; simp
+  norm_map' f := by
+    show ‖ContinuousLinearMap.flipAlternating f‖ = ‖f‖
+    refine le_antisymm ?_ ?_
+    · refine ContinuousAlternatingMap.opNorm_le_bound _ (norm_nonneg f) fun v => ?_
+      refine ContinuousLinearMap.opNorm_le_bound _ (by positivity) fun m' => ?_
+      rw [ContinuousLinearMap.flipAlternating_apply_apply]
+      calc ‖(f m') v‖ ≤ ‖f m'‖ * ∏ i, ‖v i‖ := (f m').le_opNorm v
+        _ ≤ (‖f‖ * ‖m'‖) * ∏ i, ‖v i‖ := by gcongr; exact f.le_opNorm m'
+        _ = (‖f‖ * ∏ i, ‖v i‖) * ‖m'‖ := by ring
+    · refine ContinuousLinearMap.opNorm_le_bound _
+        (norm_nonneg (ContinuousLinearMap.flipAlternating f)) fun m' => ?_
+      refine ContinuousAlternatingMap.opNorm_le_bound _ (by positivity) fun v => ?_
+      rw [show (f m') v = (ContinuousLinearMap.flipAlternating f) v m' from
+            (ContinuousLinearMap.flipAlternating_apply_apply f v m').symm]
+      calc ‖((ContinuousLinearMap.flipAlternating f) v) m'‖
+            ≤ ‖(ContinuousLinearMap.flipAlternating f) v‖ * ‖m'‖ :=
+              ((ContinuousLinearMap.flipAlternating f) v).le_opNorm m'
+        _ ≤ (‖ContinuousLinearMap.flipAlternating f‖ * ∏ i, ‖v i‖) * ‖m'‖ := by
+              gcongr; exact (ContinuousLinearMap.flipAlternating f).le_opNorm v
+        _ = (‖ContinuousLinearMap.flipAlternating f‖ * ‖m'‖) * ∏ i, ‖v i‖ := by ring
 
 -- TODO work out LinearIsometryEquiv from above to use here
 def compContinuousAlternatingMap₂ (f : N →L[𝕜] N' →L[𝕜] N'')
-    (g : M [⋀^ι]→L[𝕜] N) (h : M' [⋀^ι']→L[𝕜] N') : M [⋀^ι]→L[𝕜] M' [⋀^ι']→L[𝕜] N'' where
-  toFun v := (f (g v)).compContinuousAlternatingMap h
-  map_update_add' := sorry
-  map_update_smul' := sorry
-  cont := sorry
-  map_eq_zero_of_eq' := sorry
+    (g : M [⋀^ι]→L[𝕜] N) (h : M' [⋀^ι']→L[𝕜] N') : M [⋀^ι]→L[𝕜] M' [⋀^ι']→L[𝕜] N'' :=
+  (((ContinuousLinearMap.compContinuousAlternatingMapCLM 𝕜 M' N' N'').flip h).comp
+    f).compContinuousAlternatingMap g
 
 theorem compContinuousAlternatingMap₂_apply (f : N →L[𝕜] N' →L[𝕜] N'')
     (g : M [⋀^ι]→L[𝕜] N) (h : M' [⋀^ι']→L[𝕜] N') (m : ι → M) (m': ι' → M') :
@@ -70,13 +96,22 @@ def flipAlternating (f : ContinuousMultilinearMap 𝕜 (fun _ : ι ↦ M) (M' [�
     { toFun := fun m =>
         MultilinearMap.mkContinuous
           { toFun := fun m' => f m' m
-            map_update_add' := sorry
-            map_update_smul' := sorry }
-          1 sorry
-      map_update_add' := sorry
-      map_update_smul' := sorry
-      map_eq_zero_of_eq' := sorry }
-    1 sorry
+            map_update_add' := fun m' i x y => by rw [f.map_update_add m' i x y]; rfl
+            map_update_smul' := fun m' i c x => by rw [f.map_update_smul m' i c x]; rfl }
+          (‖f‖ * ∏ j, ‖m j‖)
+          (fun m' => by
+            calc ‖f m' m‖ ≤ ‖f m'‖ * ∏ j, ‖m j‖ := (f m').le_opNorm m
+              _ ≤ (‖f‖ * ∏ i, ‖m' i‖) * ∏ j, ‖m j‖ := by gcongr; exact f.le_opNorm m'
+              _ = (‖f‖ * ∏ j, ‖m j‖) * ∏ i, ‖m' i‖ := by ring)
+      map_update_add' := fun m i x y => by ext m'; simp [(f m').map_update_add]
+      map_update_smul' := fun m i c x => by ext m'; simp [(f m').map_update_smul]
+      map_eq_zero_of_eq' := fun m i j h hij => by
+        ext m'; simp [(f m').map_eq_zero_of_eq m h hij] }
+    ‖f‖
+    (fun m => ContinuousMultilinearMap.opNorm_le_bound (by positivity) fun m'' => by
+      calc ‖f m'' m‖ ≤ ‖f m''‖ * ∏ j, ‖m j‖ := (f m'').le_opNorm m
+        _ ≤ (‖f‖ * ∏ i, ‖m'' i‖) * ∏ j, ‖m j‖ := by gcongr; exact f.le_opNorm m''
+        _ = (‖f‖ * ∏ j, ‖m j‖) * ∏ i, ‖m'' i‖ := by ring)
 
 theorem flipAlternating_apply (f : ContinuousMultilinearMap 𝕜 (fun _ : ι ↦ M) (M' [⋀^ι']→L[𝕜] N))
     (m : ι → M) (m' : ι' → M') : flipAlternating f m' m = f m m' :=
@@ -120,14 +155,23 @@ def flipAlternating (f : M [⋀^ι]→L[𝕜] (M' [⋀^ι']→L[𝕜] N)) :
     { toFun := fun m =>
         AlternatingMap.mkContinuous
           { toFun := fun m' => f m' m
-            map_update_add' := sorry
-            map_update_smul' := sorry
-            map_eq_zero_of_eq' := sorry }
-          1 sorry
-      map_update_add' := sorry
-      map_update_smul' := sorry
-      map_eq_zero_of_eq' := sorry }
-    1 sorry
+            map_update_add' := fun m' i x y => by rw [f.map_update_add m' i x y]; rfl
+            map_update_smul' := fun m' i c x => by rw [f.map_update_smul m' i c x]; rfl
+            map_eq_zero_of_eq' := fun m' i j h hij => by rw [f.map_eq_zero_of_eq m' h hij]; rfl }
+          (‖f‖ * ∏ j, ‖m j‖)
+          (fun m' => by
+            calc ‖f m' m‖ ≤ ‖f m'‖ * ∏ j, ‖m j‖ := (f m').le_opNorm m
+              _ ≤ (‖f‖ * ∏ i, ‖m' i‖) * ∏ j, ‖m j‖ := by gcongr; exact f.le_opNorm m'
+              _ = (‖f‖ * ∏ j, ‖m j‖) * ∏ i, ‖m' i‖ := by ring)
+      map_update_add' := fun m i x y => by ext m'; simp [(f m').map_update_add]
+      map_update_smul' := fun m i c x => by ext m'; simp [(f m').map_update_smul]
+      map_eq_zero_of_eq' := fun m i j h hij => by
+        ext m'; simp [(f m').map_eq_zero_of_eq m h hij] }
+    ‖f‖
+    (fun m => ContinuousAlternatingMap.opNorm_le_bound _ (by positivity) fun m'' => by
+      calc ‖f m'' m‖ ≤ ‖f m''‖ * ∏ j, ‖m j‖ := (f m'').le_opNorm m
+        _ ≤ (‖f‖ * ∏ i, ‖m'' i‖) * ∏ j, ‖m j‖ := by gcongr; exact f.le_opNorm m''
+        _ = (‖f‖ * ∏ j, ‖m j‖) * ∏ i, ‖m'' i‖ := by ring)
 
 theorem flipAlternating_apply (f : M [⋀^ι]→L[𝕜] (M' [⋀^ι']→L[𝕜] N))
     (m : ι → M) (m' : ι' → M') : flipAlternating f m' m = f m m' :=

--- a/DeRhamCohomology/ContinuousAlternatingMap/Wedge.lean
+++ b/DeRhamCohomology/ContinuousAlternatingMap/Wedge.lean
@@ -87,17 +87,9 @@ lemma sign_addAssocPerm (σ₁ : Equiv.Perm ((Fin m ⊕ Fin n) ⊕ Fin p)) :
 --     rcases x with ⟨σ₁⟩
 --     simp
 
-/- Associativity of multiplication wedge product -/
-theorem wedge_mul_assoc (g : M [⋀^Fin m]→L[𝕜] 𝕜) (h : M [⋀^Fin n]→L[𝕜] 𝕜)
-    (l : M [⋀^Fin p]→L[𝕜] 𝕜) (v : Fin (m + n + p) → M):
-    ContinuousAlternatingMap.domDomCongr finAssoc.symm (g ∧[𝕜] h ∧[𝕜] l) v = ((g ∧[𝕜] h) ∧[𝕜] l) v := by
-  rw[wedge_product_def, uncurryFinAdd, domDomCongr_apply, domDomCongr_apply, uncurrySum_apply,
-    ContinuousMultilinearMap.sum_apply, wedge_product_def, uncurryFinAdd, domDomCongr_apply,
-    uncurrySum_apply, ContinuousMultilinearMap.sum_apply]
-  rw[wedge_product, wedge_product]
-  rw[uncurryFinAdd, uncurryFinAdd]
-  -- Want to have functionality to partially unpack
-  sorry
+/- Associativity of multiplication wedge product (`wedge_mul_assoc`) is proved in
+`DeRhamCohomology.ContinuousAlternatingMap.WedgeAssoc`, since the argument routes through the
+shuffle-sum infrastructure of `WedgeFDeriv` (which imports this file). -/
 
 /- Left distributivity of wedge product -/
 theorem add_wedge (g₁ g₂ : M [⋀^Fin m]→L[𝕜] N) (h : M [⋀^Fin n]→L[𝕜] N') (f : N →L[𝕜] N' →L[𝕜] N'') :

--- a/DeRhamCohomology/ContinuousAlternatingMap/Wedge.lean
+++ b/DeRhamCohomology/ContinuousAlternatingMap/Wedge.lean
@@ -200,7 +200,7 @@ lemma finAddCongr_symm_finAddCongr_symm (i : Fin (m + n)) :
   rfl
 
 def finSumCongr : Fin m ⊕ Fin n ≃ Fin n ⊕ Fin m :=
-  finSumFinEquiv.trans (finAddCongr.trans finSumFinEquiv.symm)
+  Equiv.sumComm (Fin m) (Fin n)
 
 def addCongrPerm : Equiv.Perm (Fin (m + n)) ≃ Equiv.Perm (Fin (n + m)) :=
   Equiv.permCongr finAddCongr
@@ -221,7 +221,7 @@ lemma sumCongrPerm_spec (a b : Equiv.Perm (Fin m ⊕ Fin n))
       (Quot.mk (QuotientGroup.leftRel (sumCongrHom (Fin n) (Fin m)).range) ∘ sumCongrPerm) b := by
   apply Quot.sound
   rw [@QuotientGroup.leftRel_apply] at h ⊢
-  simp only [sumCongrPerm, Equiv.permCongr_def]
+  simp only [sumCongrPerm, finSumCongr, Equiv.permCongr_def]
   rw [inv_def, mul_def]
   simp at h
   rcases h with ⟨ σ, τ, h ⟩
@@ -231,13 +231,11 @@ lemma sumCongrPerm_spec (a b : Equiv.Perm (Fin m ⊕ Fin n))
   · simp
     apply_fun (fun f => f (Sum.inr x)) at h
     simp [inv_def] at h
-    rw [← Equiv.symm_apply_eq]
-    sorry
+    rw[← h]; rfl
   · simp
     apply_fun (fun f => f (Sum.inl y)) at h
     simp [inv_def] at h
-    rw [← Equiv.symm_apply_eq]
-    sorry
+    rw[← h]; rfl
 
 @[simp]
 lemma sign_sumCongrPerm (σ₁ : Equiv.Perm (Fin m ⊕ Fin n)) :
@@ -258,19 +256,16 @@ def finAddCongr_equiv : ModSumCongr (Fin m) (Fin n) ≃ ModSumCongr (Fin n) (Fin
     rcases x with ⟨σ₁⟩
     simp
 
--- UNUSED functionality
 @[simps!]
 def sumCommPerm : Equiv.Perm (Fin m ⊕ Fin n) ≃ Equiv.Perm (Fin n ⊕ Fin m) :=
   Equiv.permCongr (Equiv.sumComm (Fin m) (Fin n))
 
--- UNUSED functionality
 @[simp]
 lemma sumCommPerm_sumCommPerm (σ₁ : Equiv.Perm (Fin m ⊕ Fin n)) :
     sumCommPerm (sumCommPerm σ₁) = σ₁ := by
   ext i
   simp
 
--- UNUSED functionality
 open Equiv.Perm in
 lemma sumCommPerm_spec (a b : Equiv.Perm (Fin m ⊕ Fin n))
     (h : (QuotientGroup.leftRel (Equiv.Perm.sumCongrHom (Fin m) (Fin n)).range) a b) :
@@ -296,13 +291,11 @@ lemma sumCommPerm_spec (a b : Equiv.Perm (Fin m ⊕ Fin n))
     rw[← h]
     rfl
 
--- UNUSED functionality
 @[simp]
 lemma sign_sumCommPerm (σ₁ : Equiv.Perm (Fin m ⊕ Fin n)) :
     Equiv.Perm.sign (sumCommPerm σ₁) = Equiv.Perm.sign σ₁ := by
   simp only [sumCommPerm, Equiv.Perm.sign_permCongr]
 
--- UNUSED functionality
 open Equiv.Perm in
 @[simps!]
 def finAddFlip_equiv : ModSumCongr (Fin m) (Fin n) ≃ ModSumCongr (Fin n) (Fin m) where
@@ -317,6 +310,103 @@ def finAddFlip_equiv : ModSumCongr (Fin m) (Fin n) ≃ ModSumCongr (Fin n) (Fin 
     rcases x with ⟨σ₁⟩
     simp
 
+lemma finRotate_pow_apply {N : ℕ} [NeZero N] (k : ℕ) (i : Fin N) :
+    ((finRotate N) ^ k) i = i + (k : Fin N) := by
+  induction k with
+  | zero => simp
+  | succ j ih =>
+    rw [pow_succ', Equiv.Perm.mul_apply, ih]
+    obtain ⟨N', rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne N)
+    rw [finRotate_succ_apply]
+    push_cast
+    ring
+
+lemma sign_finRotate_pow (n m : ℕ) :
+    Equiv.Perm.sign ((finRotate (n+m)) ^ m) = (-1)^(m*n) := by
+  rw [map_pow]
+  rcases Nat.eq_zero_or_pos m with rfl | hm
+  · simp
+  · obtain ⟨m', rfl⟩ := Nat.exists_eq_succ_of_ne_zero hm.ne'
+    rw [show n + (m'+1) = (n+m') + 1 by omega, sign_finRotate, ← pow_mul]
+    apply neg_one_pow_congr
+    rw [Nat.even_mul, Nat.even_mul, Nat.even_add, Nat.even_add_one]
+    tauto
+
+/-- The value-preserving relabelling `Fin m ⊕ Fin n ≃ Fin n ⊕ Fin m`, i.e. the conjugate of
+`finAddCongr` by `finSumFinEquiv`. In contrast to `finSumCongr` (the block swap) this does not
+map the `Fin m` block to the `Fin m` block. -/
+def finSumAddCongr : Fin m ⊕ Fin n ≃ Fin n ⊕ Fin m :=
+  finSumFinEquiv.trans (finAddCongr.trans finSumFinEquiv.symm)
+
+/-- The block-rotation permutation of `Fin n ⊕ Fin m`: block swap followed by the
+value-preserving relabelling. Conjugate to rotation by `m` on `Fin (n + m)`, hence of
+sign `(-1)^(m*n)`. -/
+def sumRotatePerm : Equiv.Perm (Fin n ⊕ Fin m) :=
+  (Equiv.sumComm (Fin n) (Fin m)).trans finSumAddCongr
+
+lemma sumRotatePerm_conj (x : Fin n ⊕ Fin m) :
+    finSumFinEquiv (sumRotatePerm x) = ((finRotate (n+m))^m) (finSumFinEquiv x) := by
+  rcases x with k | j
+  · haveI : NeZero (n+m) := ⟨by have := k.2; omega⟩
+    have hk : (k:ℕ) < n := k.2
+    rw [finRotate_pow_apply]
+    simp only [sumRotatePerm, finSumAddCongr, Equiv.trans_apply, Equiv.sumComm_apply, Sum.swap_inl,
+      finSumFinEquiv_apply_right, finSumFinEquiv_apply_left, Equiv.apply_symm_apply]
+    rw [Fin.ext_iff, Fin.val_add, Fin.val_natCast]
+    simp only [finAddCongr, finCongr_apply, Fin.coe_cast, Fin.coe_natAdd, Fin.coe_castAdd]
+    rw [Nat.mod_eq_of_lt (show m < n + m by omega),
+      Nat.mod_eq_of_lt (show (k:ℕ) + m < n + m by omega)]
+    omega
+  · haveI : NeZero (n+m) := ⟨by have := j.2; omega⟩
+    have hj : (j:ℕ) < m := j.2
+    rw [finRotate_pow_apply]
+    simp only [sumRotatePerm, finSumAddCongr, Equiv.trans_apply, Equiv.sumComm_apply, Sum.swap_inr,
+      finSumFinEquiv_apply_right, finSumFinEquiv_apply_left, Equiv.apply_symm_apply]
+    rw [Fin.ext_iff, Fin.val_add, Fin.val_natCast]
+    simp only [finAddCongr, finCongr_apply, Fin.coe_cast, Fin.coe_natAdd, Fin.coe_castAdd]
+    rcases Nat.eq_zero_or_pos n with hn | hn
+    · subst hn
+      simp only [Nat.zero_add, Nat.mod_self, Nat.add_zero]
+      rw [Nat.mod_eq_of_lt hj]
+    · rw [Nat.mod_eq_of_lt (show m < n + m by omega),
+        show n + (j:ℕ) + m = (n+m) + (j:ℕ) by omega, Nat.add_mod_left,
+        Nat.mod_eq_of_lt (show (j:ℕ) < n + m by omega)]
+
+@[simp]
+lemma sign_sumRotatePerm : Equiv.Perm.sign (sumRotatePerm (m:=m) (n:=n)) = (-1)^(m*n) := by
+  rw [Equiv.Perm.sign_eq_sign_of_equiv sumRotatePerm _ finSumFinEquiv sumRotatePerm_conj,
+    sign_finRotate_pow]
+
+open Equiv.Perm in
+/-- The reindexing of `ModSumCongr` used in `wedge_antisymm`: the block swap `finAddFlip_equiv`
+followed by left multiplication with the block rotation `sumRotatePerm`. On representatives it
+sends `σ` to `sumRotatePerm * sumCommPerm σ`, which composes with `finAddCongr` to permute the
+arguments of the two factors of the wedge product exactly. -/
+def wedgeFlipEquiv : ModSumCongr (Fin m) (Fin n) ≃ ModSumCongr (Fin n) (Fin m) :=
+  finAddFlip_equiv.trans (MulAction.toPerm (sumRotatePerm : Equiv.Perm (Fin n ⊕ Fin m)))
+
+lemma wedgeFlipEquiv_mk (σ : Equiv.Perm (Fin m ⊕ Fin n)) :
+    wedgeFlipEquiv (Quot.mk _ σ) = Quot.mk _ (sumRotatePerm * sumCommPerm σ) := by
+  simp only [wedgeFlipEquiv, Equiv.trans_apply, finAddFlip_equiv_apply, Function.comp_apply,
+    MulAction.toPerm_apply]
+  exact MulAction.Quotient.smul_mk _ _ _
+
+lemma wedgeFlip_arg_inl (σ : Equiv.Perm (Fin m ⊕ Fin n)) (k : Fin n) :
+    finAddCongr (finSumFinEquiv
+        ((sumRotatePerm * sumCommPerm σ : Equiv.Perm (Fin n ⊕ Fin m)) (Sum.inl k)))
+      = finSumFinEquiv (σ (Sum.inr k)) := by
+  simp only [Equiv.Perm.mul_apply, sumRotatePerm, finSumAddCongr, sumCommPerm, finSumCongr,
+    Equiv.permCongr_apply, Equiv.trans_apply, Equiv.sumComm_apply, Equiv.sumComm_symm,
+    Sum.swap_inl, Sum.swap_swap, Equiv.apply_symm_apply, finAddCongr_finAddCongr]
+
+lemma wedgeFlip_arg_inr (σ : Equiv.Perm (Fin m ⊕ Fin n)) (j : Fin m) :
+    finAddCongr (finSumFinEquiv
+        ((sumRotatePerm * sumCommPerm σ : Equiv.Perm (Fin n ⊕ Fin m)) (Sum.inr j)))
+      = finSumFinEquiv (σ (Sum.inl j)) := by
+  simp only [Equiv.Perm.mul_apply, sumRotatePerm, finSumAddCongr, sumCommPerm, finSumCongr,
+    Equiv.permCongr_apply, Equiv.trans_apply, Equiv.sumComm_apply, Equiv.sumComm_symm,
+    Sum.swap_inr, Sum.swap_swap, Equiv.apply_symm_apply, finAddCongr_finAddCongr]
+
 /- Antisymmetry of multiplication wedge product -/
 theorem wedge_antisymm (g : M [⋀^Fin m]→L[𝕜] 𝕜) (h : M [⋀^Fin n]→L[𝕜] 𝕜) :
     (g ∧[𝕜] h) = ((-1 : 𝕜)^(m*n) • (h ∧[𝕜] g)).domDomCongr finAddCongr := by
@@ -324,12 +414,12 @@ theorem wedge_antisymm (g : M [⋀^Fin m]→L[𝕜] 𝕜) (h : M [⋀^Fin n]→L
   rw[domDomCongr_apply, smul_apply, wedge_product_mul, uncurryFinAdd, domDomCongr_apply,
     uncurrySum_apply, ContinuousMultilinearMap.sum_apply, wedge_product_mul,
     uncurryFinAdd, domDomCongr_apply, uncurrySum_apply, ContinuousMultilinearMap.sum_apply]
-  conv_rhs => rw[← Equiv.sum_comp finAddCongr_equiv]
+  conv_rhs => rw[← Equiv.sum_comp wedgeFlipEquiv]
   rw[Finset.smul_sum]
   apply Finset.sum_congr rfl
   intro σ hσ
   rcases σ with ⟨σ₁⟩
-  simp only [Function.comp_apply, finAddCongr_equiv_apply]
+  rw[wedgeFlipEquiv_mk]
   rw[uncurrySum.summand_mk]
   rw[ContinuousMultilinearMap.smul_apply, ContinuousMultilinearMap.domDomCongr_apply,
     ContinuousMultilinearMap.uncurrySum_apply, ContinuousMultilinearMap.flipMultilinear_apply,
@@ -342,15 +432,19 @@ theorem wedge_antisymm (g : M [⋀^Fin m]→L[𝕜] 𝕜) (h : M [⋀^Fin n]→L
     coe_toContinuousMultilinearMap, ContinuousMultilinearMap.flipAlternating_apply,
     coe_toContinuousMultilinearMap, ContinuousLinearMap.compContinuousAlternatingMap₂_apply,
     ContinuousLinearMap.mul_apply']
-  simp only [sign_sumCommPerm, sumCommPerm_apply_apply, Function.comp_apply]
-  simp [Function.comp_def, finAddFlip]
-  simp_rw[mul_comm]
-  simp only [sumCongrPerm, finSumCongr, Equiv.permCongr_apply, Equiv.symm_trans_apply,
-    Equiv.symm_symm, Equiv.trans_apply, Equiv.apply_symm_apply,
-    finAddCongr_finAddCongr]
-
-
-  sorry
+  have harg1 : ((fun i => ((x ∘ ⇑finAddCongr) ∘ ⇑finSumFinEquiv)
+        ((sumRotatePerm * sumCommPerm σ₁ : Equiv.Perm (Fin n ⊕ Fin m)) i)) ∘ Sum.inl)
+      = ((fun i => (x ∘ ⇑finSumFinEquiv) (σ₁ i)) ∘ Sum.inr) :=
+    funext fun k => congrArg x (wedgeFlip_arg_inl σ₁ k)
+  have harg2 : ((fun i => ((x ∘ ⇑finAddCongr) ∘ ⇑finSumFinEquiv)
+        ((sumRotatePerm * sumCommPerm σ₁ : Equiv.Perm (Fin n ⊕ Fin m)) i)) ∘ Sum.inr)
+      = ((fun i => (x ∘ ⇑finSumFinEquiv) (σ₁ i)) ∘ Sum.inl) :=
+    funext fun j => congrArg x (wedgeFlip_arg_inr σ₁ j)
+  rw [harg1, harg2, map_mul, sign_sumRotatePerm, sign_sumCommPerm,
+    mul_comm (h _) (g _), mul_smul]
+  rw [Units.smul_def ((-1:ℤˣ)^(m*n)), Units.val_pow_eq_pow_val, Units.val_neg, Units.val_one,
+    zsmul_eq_mul, Int.cast_pow, Int.cast_neg, Int.cast_one, smul_eq_mul, ← mul_assoc,
+    ← pow_add, Even.neg_one_pow ⟨m*n, rfl⟩, one_mul]
 
 variable {M : Type*} [NormedAddCommGroup M] [NormedSpace ℝ M]
 

--- a/DeRhamCohomology/ContinuousAlternatingMap/Wedge.lean
+++ b/DeRhamCohomology/ContinuousAlternatingMap/Wedge.lean
@@ -446,6 +446,46 @@ theorem wedge_antisymm (g : M [⋀^Fin m]→L[𝕜] 𝕜) (h : M [⋀^Fin n]→L
     zsmul_eq_mul, Int.cast_pow, Int.cast_neg, Int.cast_one, smul_eq_mul, ← mul_assoc,
     ← pow_add, Even.neg_one_pow ⟨m*n, rfl⟩, one_mul]
 
+/-- General-`f` antisymmetry of the wedge product: swapping the two factors swaps the bilinear
+pairing to its flip, costs the Koszul sign `(-1)^(m*n)`, and reindexes by `finAddCongr`.
+This generalises `wedge_antisymm` from the scalar-multiplication pairing to an arbitrary `f`. -/
+theorem wedge_flip (g : M [⋀^Fin m]→L[𝕜] N) (h : M [⋀^Fin n]→L[𝕜] N')
+    (f : N →L[𝕜] N' →L[𝕜] N'') :
+    (g ∧[f] h) = ((-1 : 𝕜) ^ (m * n) • (h ∧[f.flip] g)).domDomCongr finAddCongr := by
+  ext x
+  rw [domDomCongr_apply, smul_apply, wedge_product_def, uncurryFinAdd, domDomCongr_apply,
+    uncurrySum_apply, ContinuousMultilinearMap.sum_apply, wedge_product_def,
+    uncurryFinAdd, domDomCongr_apply, uncurrySum_apply, ContinuousMultilinearMap.sum_apply]
+  conv_rhs => rw [← Equiv.sum_comp wedgeFlipEquiv]
+  rw [Finset.smul_sum]
+  apply Finset.sum_congr rfl
+  intro σ hσ
+  rcases σ with ⟨σ₁⟩
+  rw [wedgeFlipEquiv_mk]
+  rw [uncurrySum.summand_mk]
+  rw [ContinuousMultilinearMap.smul_apply, ContinuousMultilinearMap.domDomCongr_apply,
+    ContinuousMultilinearMap.uncurrySum_apply, ContinuousMultilinearMap.flipMultilinear_apply,
+    coe_toContinuousMultilinearMap, ContinuousMultilinearMap.flipAlternating_apply,
+    coe_toContinuousMultilinearMap, ContinuousLinearMap.compContinuousAlternatingMap₂_apply]
+  rw [uncurrySum.summand_mk]
+  rw [ContinuousMultilinearMap.smul_apply, ContinuousMultilinearMap.domDomCongr_apply,
+    ContinuousMultilinearMap.uncurrySum_apply, ContinuousMultilinearMap.flipMultilinear_apply,
+    coe_toContinuousMultilinearMap, ContinuousMultilinearMap.flipAlternating_apply,
+    coe_toContinuousMultilinearMap, ContinuousLinearMap.compContinuousAlternatingMap₂_apply]
+  have harg1 : ((fun i => ((x ∘ ⇑finAddCongr) ∘ ⇑finSumFinEquiv)
+        ((sumRotatePerm * sumCommPerm σ₁ : Equiv.Perm (Fin n ⊕ Fin m)) i)) ∘ Sum.inl)
+      = ((fun i => (x ∘ ⇑finSumFinEquiv) (σ₁ i)) ∘ Sum.inr) :=
+    funext fun k => congrArg x (wedgeFlip_arg_inl σ₁ k)
+  have harg2 : ((fun i => ((x ∘ ⇑finAddCongr) ∘ ⇑finSumFinEquiv)
+        ((sumRotatePerm * sumCommPerm σ₁ : Equiv.Perm (Fin n ⊕ Fin m)) i)) ∘ Sum.inr)
+      = ((fun i => (x ∘ ⇑finSumFinEquiv) (σ₁ i)) ∘ Sum.inl) :=
+    funext fun j => congrArg x (wedgeFlip_arg_inr σ₁ j)
+  rw [harg1, harg2, ContinuousLinearMap.flip_apply, map_mul, sign_sumRotatePerm,
+    sign_sumCommPerm, mul_smul]
+  rw [Units.smul_def ((-1 : ℤˣ) ^ (m * n)), Units.val_pow_eq_pow_val, Units.val_neg,
+    Units.val_one, ← Int.cast_smul_eq_zsmul 𝕜, Int.cast_pow, Int.cast_neg, Int.cast_one, smul_smul,
+    ← pow_add, Even.neg_one_pow ⟨m * n, rfl⟩, one_smul]
+
 variable {M : Type*} [NormedAddCommGroup M] [NormedSpace ℝ M]
 
 -- UNUSED functionality

--- a/DeRhamCohomology/ContinuousAlternatingMap/WedgeAssoc.lean
+++ b/DeRhamCohomology/ContinuousAlternatingMap/WedgeAssoc.lean
@@ -1,0 +1,629 @@
+import DeRhamCohomology.ContinuousAlternatingMap.WedgeFDeriv
+
+/-!
+# Associativity of the wedge product
+
+This file proves `wedge_mul_assoc`, the associativity of the (multiplication) wedge product on
+continuous alternating maps, the thesis's Prop. 4.27 / §5.2.1.
+
+The heart is `core_assoc`: an abstract associativity of the alternatization shuffle product over
+arbitrary `Sum` index types, proved by exhibiting both nested shuffle sums as a single sum over the
+triple Young quotient `T ι κ μ` via two fibrations (`lcore_eq_sumT`, `rcore_eq_sumT`). The two
+`pullout` lemmas move the `finSumFinEquiv` reindexings out of the wedge factors, reducing the Fin
+statement to `core_assoc` after the value-preserving recast reconciliation `eR3_eq_sumAssoc_eL3`.
+-/
+
+noncomputable section
+suppress_compilation
+
+namespace ContinuousAlternatingMap
+
+open scoped BigOperators
+open Equiv Equiv.Perm
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {M : Type*} [NormedAddCommGroup M] [NormedSpace 𝕜 M]
+  {m n p : ℕ}
+
+/-- Value-preserving linearization of the right-nested triple `Fin m ⊕ (Fin n ⊕ Fin p)`. -/
+def eL3 : Fin m ⊕ (Fin n ⊕ Fin p) ≃ Fin (m + n + p) :=
+  ((Equiv.sumCongr (Equiv.refl (Fin m)) finSumFinEquiv).trans finSumFinEquiv).trans finAssoc.symm
+
+/-- Value-preserving linearization of the left-nested triple `(Fin m ⊕ Fin n) ⊕ Fin p`. -/
+def eR3 : (Fin m ⊕ Fin n) ⊕ Fin p ≃ Fin (m + n + p) :=
+  (Equiv.sumCongr finSumFinEquiv (Equiv.refl (Fin p))).trans finSumFinEquiv
+
+@[simp] theorem eL3_inl (i : Fin m) : (eL3 (n := n) (p := p) (Sum.inl i) : ℕ) = i := by
+  simp only [eL3, finAssoc, Equiv.trans_apply, Equiv.sumCongr_apply, Sum.map_inl, Equiv.refl_apply,
+    finSumFinEquiv_apply_left, finCongr_symm, finCongr_apply, Fin.coe_cast, Fin.coe_castAdd]
+
+@[simp] theorem eL3_inr_inl (j : Fin n) : (eL3 (m := m) (p := p) (Sum.inr (Sum.inl j)) : ℕ) = m + j := by
+  simp only [eL3, finAssoc, Equiv.trans_apply, Equiv.sumCongr_apply, Sum.map_inr, Equiv.refl_apply,
+    finSumFinEquiv_apply_left, finSumFinEquiv_apply_right, finCongr_symm, finCongr_apply,
+    Fin.coe_cast, Fin.coe_natAdd, Fin.coe_castAdd]
+
+@[simp] theorem eL3_inr_inr (k : Fin p) : (eL3 (m := m) (n := n) (Sum.inr (Sum.inr k)) : ℕ) = m + n + k := by
+  simp only [eL3, finAssoc, Equiv.trans_apply, Equiv.sumCongr_apply, Sum.map_inr, Equiv.refl_apply,
+    finSumFinEquiv_apply_right, finCongr_symm, finCongr_apply, Fin.coe_cast, Fin.coe_natAdd]
+  omega
+
+@[simp] theorem eR3_inl_inl (i : Fin m) : (eR3 (n := n) (p := p) (Sum.inl (Sum.inl i)) : ℕ) = i := by
+  simp only [eR3, Equiv.trans_apply, Equiv.sumCongr_apply, Sum.map_inl, finSumFinEquiv_apply_left,
+    Fin.coe_castAdd]
+
+@[simp] theorem eR3_inl_inr (j : Fin n) : (eR3 (m := m) (p := p) (Sum.inl (Sum.inr j)) : ℕ) = m + j := by
+  simp only [eR3, Equiv.trans_apply, Equiv.sumCongr_apply, Sum.map_inl, Sum.map_inr,
+    Equiv.refl_apply, finSumFinEquiv_apply_left, finSumFinEquiv_apply_right, Fin.coe_castAdd,
+    Fin.coe_natAdd]
+
+@[simp] theorem eR3_inr (k : Fin p) : (eR3 (m := m) (n := n) (Sum.inr k) : ℕ) = m + n + k := by
+  simp only [eR3, Equiv.trans_apply, Equiv.sumCongr_apply, Sum.map_inr, Equiv.refl_apply,
+    finSumFinEquiv_apply_right, Fin.coe_natAdd]
+
+/-- The two linearizations agree after `Equiv.sumAssoc`: `eR3 = sumAssoc.trans eL3`. -/
+theorem eR3_eq_sumAssoc_eL3 :
+    eR3 = (Equiv.sumAssoc (Fin m) (Fin n) (Fin p)).trans eL3 := by
+  ext x
+  rcases x with (i | j) | k
+  · simp
+  · simp
+  · simp
+
+/-! ### Abstract core: associativity of the alternatization shuffle over `Sum` index types -/
+
+section core
+
+variable {ι κ μ : Type*} [Fintype ι] [Fintype κ] [Fintype μ]
+  [DecidableEq ι] [DecidableEq κ] [DecidableEq μ]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+
+/-- Applying a continuous alternating map to a permuted argument tuple picks up the sign. -/
+theorem cam_apply_perm {ν : Type*} [Fintype ν] [DecidableEq ν]
+    (a : E [⋀^ν]→L[𝕜] 𝕜) (w : ν → E) (s : Equiv.Perm ν) :
+    a (w ∘ s) = Equiv.Perm.sign s • a w := by
+  have h := a.toAlternatingMap.map_congr_perm (v := w) s
+  have hcoe : ∀ x : ν → E, a.toAlternatingMap x = a x := fun _ => rfl
+  rw [hcoe, hcoe] at h
+  rw [h, smul_smul, Int.units_mul_self, one_smul]
+
+/-- The Young subgroup hom: `(sι, sκ, sμ) ↦ sumCongr sι (sumCongr sκ sμ)`, embedding
+`Perm ι × Perm κ × Perm μ` block-diagonally into `Perm (ι ⊕ κ ⊕ μ)`. -/
+def youngHom (ι κ μ : Type*) :
+    Equiv.Perm ι × Equiv.Perm κ × Equiv.Perm μ →* Equiv.Perm (ι ⊕ κ ⊕ μ) :=
+  (Equiv.Perm.sumCongrHom ι (κ ⊕ μ)).comp
+    ((MonoidHom.id (Equiv.Perm ι)).prodMap (Equiv.Perm.sumCongrHom κ μ))
+
+@[simp] theorem youngHom_apply (sι : Equiv.Perm ι) (sκ : Equiv.Perm κ) (sμ : Equiv.Perm μ) :
+    youngHom ι κ μ (sι, sκ, sμ) = Equiv.sumCongr sι (Equiv.sumCongr sκ sμ) := rfl
+
+/-- Membership in the Young range is decidable (the lambda is needed for instance synthesis,
+mirroring `Equiv.Perm.sumCongrHom.decidableMemRange`). -/
+instance youngHom.decidableMemRange : DecidablePred (· ∈ (youngHom ι κ μ).range) :=
+  fun _ => inferInstance
+
+instance decidableMemRange_sumCongrHom_right :
+    DecidablePred (· ∈ (Equiv.Perm.sumCongrHom ι (κ ⊕ μ)).range) := fun _ => inferInstance
+
+instance decidableMemRange_sumCongrHom_left :
+    DecidablePred (· ∈ (Equiv.Perm.sumCongrHom (ι ⊕ κ) μ).range) := fun _ => inferInstance
+
+/-- The triple shuffle quotient: permutations of `ι ⊕ κ ⊕ μ` modulo block-diagonal relabellings. -/
+abbrev T (ι κ μ : Type*) := Equiv.Perm (ι ⊕ κ ⊕ μ) ⧸ (youngHom ι κ μ).range
+
+/-- The triple-shuffle summand at a representative `A`: the signed product `g·h·l`. -/
+def ttermFun (a : E [⋀^ι]→L[𝕜] 𝕜) (b : E [⋀^κ]→L[𝕜] 𝕜) (c : E [⋀^μ]→L[𝕜] 𝕜)
+    (v : ι ⊕ κ ⊕ μ → E) (A : Equiv.Perm (ι ⊕ κ ⊕ μ)) : 𝕜 :=
+  Equiv.Perm.sign A •
+    (a (fun i => v (A (Sum.inl i)))
+      * b (fun j => v (A (Sum.inr (Sum.inl j))))
+      * c (fun k => v (A (Sum.inr (Sum.inr k)))))
+
+/-- `ttermFun` is invariant under right multiplication by the Young subgroup. -/
+theorem ttermFun_young (a : E [⋀^ι]→L[𝕜] 𝕜) (b : E [⋀^κ]→L[𝕜] 𝕜) (c : E [⋀^μ]→L[𝕜] 𝕜)
+    (v : ι ⊕ κ ⊕ μ → E) (A : Equiv.Perm (ι ⊕ κ ⊕ μ))
+    (sι : Equiv.Perm ι) (sκ : Equiv.Perm κ) (sμ : Equiv.Perm μ) :
+    ttermFun a b c v (A * Equiv.sumCongr sι (Equiv.sumCongr sκ sμ)) = ttermFun a b c v A := by
+  have ha : (fun i => v ((A * Equiv.sumCongr sι (Equiv.sumCongr sκ sμ)) (Sum.inl i)))
+      = (fun i => v (A (Sum.inl i))) ∘ sι := by
+    funext i; simp [Equiv.Perm.mul_apply]
+  have hb : (fun j => v ((A * Equiv.sumCongr sι (Equiv.sumCongr sκ sμ)) (Sum.inr (Sum.inl j))))
+      = (fun j => v (A (Sum.inr (Sum.inl j)))) ∘ sκ := by
+    funext j; simp [Equiv.Perm.mul_apply]
+  have hc : (fun k => v ((A * Equiv.sumCongr sι (Equiv.sumCongr sκ sμ)) (Sum.inr (Sum.inr k))))
+      = (fun k => v (A (Sum.inr (Sum.inr k)))) ∘ sμ := by
+    funext k; simp [Equiv.Perm.mul_apply]
+  rw [ttermFun, ttermFun, ha, hb, hc, cam_apply_perm, cam_apply_perm, cam_apply_perm, map_mul,
+    Equiv.Perm.sign_sumCongr, Equiv.Perm.sign_sumCongr]
+  simp only [smul_mul_assoc, mul_smul_comm, smul_smul]
+  congr 1
+  have hinv : ∀ u : ℤˣ, u⁻¹ = u := fun u => inv_eq_of_mul_eq_one_right (Int.units_mul_self u)
+  have hkey : (Equiv.Perm.sign sι * (Equiv.Perm.sign sκ * Equiv.Perm.sign sμ)) *
+      (Equiv.Perm.sign sμ * (Equiv.Perm.sign sκ * Equiv.Perm.sign sι)) = 1 := by
+    rw [mul_eq_one_iff_eq_inv, mul_inv_rev, mul_inv_rev, hinv, hinv, hinv, mul_assoc]
+  rw [mul_assoc (Equiv.Perm.sign A), hkey, mul_one]
+
+/-- The triple-shuffle summand, descended to the quotient `T`. -/
+def tterm (a : E [⋀^ι]→L[𝕜] 𝕜) (b : E [⋀^κ]→L[𝕜] 𝕜) (c : E [⋀^μ]→L[𝕜] 𝕜)
+    (v : ι ⊕ κ ⊕ μ → E) : T ι κ μ → 𝕜 :=
+  fun q => Quotient.liftOn' q (ttermFun a b c v) (by
+    intro A₁ A₂ hA
+    rw [QuotientGroup.leftRel_apply] at hA
+    obtain ⟨⟨sι, sκ, sμ⟩, h⟩ := hA
+    rw [youngHom_apply] at h
+    have hA₂ : A₂ = A₁ * Equiv.sumCongr sι (Equiv.sumCongr sκ sμ) := by
+      rw [h, mul_inv_cancel_left]
+    rw [hA₂, ttermFun_young])
+
+@[simp] theorem tterm_mk (a : E [⋀^ι]→L[𝕜] 𝕜) (b : E [⋀^κ]→L[𝕜] 𝕜) (c : E [⋀^μ]→L[𝕜] 𝕜)
+    (v : ι ⊕ κ ⊕ μ → E) (A : Equiv.Perm (ι ⊕ κ ⊕ μ)) :
+    tterm a b c v (Quotient.mk'' A) = ttermFun a b c v A := rfl
+
+/-- Forget the `κ`/`μ` split: the quotient projection `T ι κ μ → ModSumCongr ι (κ ⊕ μ)`. -/
+def projL : T ι κ μ → Equiv.Perm.ModSumCongr ι (κ ⊕ μ) :=
+  fun q => Quotient.liftOn' q (fun A => (Quotient.mk'' A : Equiv.Perm.ModSumCongr ι (κ ⊕ μ))) (by
+    intro A₁ A₂ hA
+    rw [QuotientGroup.leftRel_apply] at hA
+    obtain ⟨⟨sι, sκ, sμ⟩, h⟩ := hA
+    apply Quotient.sound'
+    rw [QuotientGroup.leftRel_apply]
+    exact ⟨(sι, Equiv.sumCongr sκ sμ), by
+      rw [Equiv.Perm.sumCongrHom_apply, ← h, youngHom_apply]⟩)
+
+@[simp] theorem projL_mk (A : Equiv.Perm (ι ⊕ κ ⊕ μ)) :
+    projL (Quotient.mk'' A) = (Quotient.mk'' A : Equiv.Perm.ModSumCongr ι (κ ⊕ μ)) := rfl
+
+/-- Insert a `κ`/`μ` split `ρ` into the right block, fibrewise over `projL`. -/
+def fibI (σ : Equiv.Perm (ι ⊕ κ ⊕ μ)) : Equiv.Perm.ModSumCongr κ μ → T ι κ μ :=
+  fun r => Quotient.liftOn' r
+    (fun ρ => Quotient.mk'' (σ * Equiv.sumCongr (1 : Equiv.Perm ι) ρ)) (by
+    intro ρ₁ ρ₂ hρ
+    rw [QuotientGroup.leftRel_apply] at hρ
+    obtain ⟨⟨sκ, sμ⟩, h⟩ := hρ
+    apply Quotient.sound'
+    rw [QuotientGroup.leftRel_apply]
+    refine ⟨(1, sκ, sμ), ?_⟩
+    rw [youngHom_apply, mul_inv_rev, mul_assoc, ← mul_assoc σ⁻¹ σ, inv_mul_cancel, one_mul,
+      Equiv.Perm.sumCongr_inv, inv_one, Equiv.Perm.sumCongr_mul, one_mul, ← h,
+      Equiv.Perm.sumCongrHom_apply])
+
+@[simp] theorem fibI_mk (σ : Equiv.Perm (ι ⊕ κ ⊕ μ)) (ρ : Equiv.Perm (κ ⊕ μ)) :
+    fibI σ (Quotient.mk'' ρ) = Quotient.mk'' (σ * Equiv.sumCongr (1 : Equiv.Perm ι) ρ) := rfl
+
+/-- Evaluate a scalar-`mul` wedge `summand` over an abstract sum index type at a representative. -/
+theorem mul_summand_eval' {ν ν' : Type*} [Fintype ν] [Fintype ν'] [DecidableEq ν] [DecidableEq ν']
+    (b : E [⋀^ν]→L[𝕜] 𝕜) (c : E [⋀^ν']→L[𝕜] 𝕜) (ρ : Equiv.Perm (ν ⊕ ν')) (w : ν ⊕ ν' → E) :
+    uncurrySum.summand ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ b c)
+        (Quotient.mk'' ρ) w
+      = Equiv.Perm.sign ρ •
+          (b (fun j => w (ρ (Sum.inl j))) * c (fun k => w (ρ (Sum.inr k)))) := by
+  rw [summand_mk_eval]
+  simp only [ContinuousLinearMap.compContinuousAlternatingMap₂_apply,
+    ContinuousLinearMap.mul_apply']
+
+/-- Expand the abstract scalar wedge `uncurrySum (mul.compCAM₂ b c)` as a sum over `ModSumCongr`. -/
+theorem uncurrySum_mul_apply {ν ν' : Type*} [Fintype ν] [Fintype ν'] [DecidableEq ν] [DecidableEq ν']
+    (b : E [⋀^ν]→L[𝕜] 𝕜) (c : E [⋀^ν']→L[𝕜] 𝕜) (w : ν ⊕ ν' → E) :
+    uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ b c) w
+      = ∑ ρ : Equiv.Perm.ModSumCongr ν ν',
+          uncurrySum.summand ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ b c) ρ w := by
+  rw [uncurrySum_apply, ContinuousMultilinearMap.sum_apply]
+
+/-- The per-fibre identity for the LHS (right) fibration. -/
+theorem lcore_fiber (a : E [⋀^ι]→L[𝕜] 𝕜) (b : E [⋀^κ]→L[𝕜] 𝕜) (c : E [⋀^μ]→L[𝕜] 𝕜)
+    (v : ι ⊕ κ ⊕ μ → E) (σ : Equiv.Perm (ι ⊕ κ ⊕ μ)) :
+    uncurrySum.summand ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ a
+        (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ b c)))
+        (Quotient.mk'' σ) v
+      = ∑ A ∈ Finset.univ.filter (fun q : T ι κ μ => projL q = Quotient.mk'' σ),
+          tterm a b c v A := by
+  rw [summand_mk_eval]
+  simp only [ContinuousLinearMap.compContinuousAlternatingMap₂_apply, ContinuousLinearMap.mul_apply']
+  rw [uncurrySum_mul_apply, Finset.mul_sum, Finset.smul_sum]
+  refine Finset.sum_bij (fun (r : Equiv.Perm.ModSumCongr κ μ) _ => fibI σ r) ?_ ?_ ?_ ?_
+  · -- maps into the fibre
+    intro r _
+    induction r using Quotient.inductionOn' with
+    | _ ρ =>
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and, fibI_mk, projL_mk]
+      apply Quotient.sound'
+      rw [QuotientGroup.leftRel_apply]
+      exact ⟨(1, ρ⁻¹), by rw [Equiv.Perm.sumCongrHom_apply, mul_inv_rev, mul_assoc,
+        inv_mul_cancel, mul_one, Equiv.Perm.sumCongr_inv, inv_one]⟩
+  · -- injective
+    intro r₁ _ r₂ _ heq
+    induction r₁ using Quotient.inductionOn' with
+    | _ ρ₁ =>
+    induction r₂ using Quotient.inductionOn' with
+    | _ ρ₂ =>
+      simp only [fibI_mk] at heq
+      rw [Quotient.eq'', QuotientGroup.leftRel_apply] at heq ⊢
+      obtain ⟨⟨sι, sκ, sμ⟩, h⟩ := heq
+      rw [youngHom_apply, mul_inv_rev, mul_assoc, inv_mul_cancel_left,
+        Equiv.Perm.sumCongr_inv, inv_one, Equiv.Perm.sumCongr_mul, one_mul] at h
+      -- h : sumCongr sι (sumCongr sκ sμ) = sumCongr 1 (ρ₁⁻¹ * ρ₂)
+      have hX : ρ₁⁻¹ * ρ₂ = Equiv.sumCongr sκ sμ := by
+        ext y
+        have := congrArg (fun e => e (Sum.inr y)) h
+        simpa using this.symm
+      exact ⟨(sκ, sμ), by simp only [Equiv.Perm.sumCongrHom_apply]; exact hX.symm⟩
+  · -- surjective
+    intro b hb
+    induction b using Quotient.inductionOn' with
+    | _ A =>
+      rw [Finset.mem_filter] at hb
+      have hcl : (Quotient.mk'' A : Equiv.Perm.ModSumCongr ι (κ ⊕ μ)) = Quotient.mk'' σ := by
+        have := hb.2; rwa [projL_mk] at this
+      rw [Quotient.eq'', QuotientGroup.leftRel_apply] at hcl
+      have hcl' : σ⁻¹ * A ∈ (Equiv.Perm.sumCongrHom ι (κ ⊕ μ)).range := by
+        have := (Equiv.Perm.sumCongrHom ι (κ ⊕ μ)).range.inv_mem hcl
+        rwa [mul_inv_rev, inv_inv] at this
+      obtain ⟨⟨sι, w⟩, hw⟩ := hcl'
+      simp only [Equiv.Perm.sumCongrHom_apply] at hw
+      have hA : A = σ * Equiv.sumCongr sι w := eq_mul_of_inv_mul_eq hw.symm
+      refine ⟨Quotient.mk'' w, Finset.mem_univ _, ?_⟩
+      simp only [fibI_mk]
+      apply Quotient.sound'
+      rw [QuotientGroup.leftRel_apply]
+      refine ⟨(sι, 1, 1), ?_⟩
+      rw [hA, mul_inv_rev, mul_assoc, inv_mul_cancel_left, Equiv.Perm.sumCongr_inv, inv_one,
+        Equiv.Perm.sumCongr_mul, one_mul, inv_mul_cancel]
+      simp [youngHom_apply]
+  · -- term identity
+    intro r _
+    induction r using Quotient.inductionOn' with
+    | _ ρ =>
+      have hsign : Equiv.Perm.sign (σ * Equiv.sumCongr (1 : Equiv.Perm ι) ρ)
+          = Equiv.Perm.sign σ * Equiv.Perm.sign ρ := by
+        rw [map_mul, Equiv.Perm.sign_sumCongr, map_one, one_mul]
+      simp only [fibI_mk, tterm_mk, ttermFun, mul_summand_eval', hsign,
+        Equiv.Perm.mul_apply, Equiv.sumCongr_apply, Sum.map_inl, Sum.map_inr,
+        Equiv.Perm.coe_one, id_eq, mul_smul_comm, smul_smul, mul_assoc]
+
+/-- **LHS core = sum over the triple quotient** (right fibration over `projL`). -/
+theorem lcore_eq_sumT (a : E [⋀^ι]→L[𝕜] 𝕜) (b : E [⋀^κ]→L[𝕜] 𝕜) (c : E [⋀^μ]→L[𝕜] 𝕜)
+    (v : ι ⊕ κ ⊕ μ → E) :
+    uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ a
+        (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ b c))) v
+      = ∑ q : T ι κ μ, tterm a b c v q := by
+  rw [uncurrySum_apply, ContinuousMultilinearMap.sum_apply,
+    ← Finset.sum_fiberwise Finset.univ projL (tterm a b c v)]
+  refine Finset.sum_congr rfl fun σ' _ => ?_
+  induction σ' using Quotient.inductionOn' with
+  | _ σ => exact lcore_fiber a b c v σ
+
+/-! #### Right (left-nested) fibration -/
+
+/-- Conjugation by an equiv is multiplicative on permutations. -/
+theorem permCongr_mul {α β : Type*} (e : α ≃ β) (p q : Equiv.Perm α) :
+    e.permCongr (p * q) = e.permCongr p * e.permCongr q := by
+  ext x; simp [Equiv.permCongr_apply, Equiv.Perm.mul_apply]
+
+theorem permCongr_one {α β : Type*} (e : α ≃ β) : e.permCongr (1 : Equiv.Perm α) = 1 := by
+  ext x; simp [Equiv.permCongr_apply]
+
+theorem permCongr_inv {α β : Type*} (e : α ≃ β) (p : Equiv.Perm α) :
+    e.permCongr p⁻¹ = (e.permCongr p)⁻¹ :=
+  (inv_eq_of_mul_eq_one_right (by rw [← permCongr_mul, mul_inv_cancel, permCongr_one])).symm
+
+@[simp] theorem permCongr_symm_permCongr {α β : Type*} (e : α ≃ β) (p : Equiv.Perm α) :
+    e.symm.permCongr (e.permCongr p) = p := by
+  rw [← Equiv.permCongr_symm, Equiv.symm_apply_apply]
+
+@[simp] theorem permCongr_permCongr_symm {α β : Type*} (e : α ≃ β) (p : Equiv.Perm β) :
+    e.permCongr (e.symm.permCongr p) = p := by
+  rw [← Equiv.permCongr_symm, Equiv.apply_symm_apply]
+
+/-- Conjugating a right-nested Young element by `sumAssoc⁻¹` gives the left-nested one. -/
+theorem permCongr_sumAssoc_symm_young (sι : Equiv.Perm ι) (sκ : Equiv.Perm κ) (sμ : Equiv.Perm μ) :
+    (Equiv.sumAssoc ι κ μ).symm.permCongr (Equiv.sumCongr sι (Equiv.sumCongr sκ sμ))
+      = Equiv.sumCongr (Equiv.sumCongr sι sκ) sμ := by
+  ext x; rcases x with (i | j) | k <;> simp [Equiv.permCongr_apply]
+
+/-- Conjugating a left-nested Young element by `sumAssoc` gives the right-nested one. -/
+theorem permCongr_sumAssoc_young (sι : Equiv.Perm ι) (sκ : Equiv.Perm κ) (sμ : Equiv.Perm μ) :
+    (Equiv.sumAssoc ι κ μ).permCongr (Equiv.sumCongr (Equiv.sumCongr sι sκ) sμ)
+      = Equiv.sumCongr sι (Equiv.sumCongr sκ sμ) := by
+  ext x; rcases x with i | j | k <;> simp [Equiv.permCongr_apply]
+
+theorem youngHom_one_one (sμ : Equiv.Perm μ) :
+    youngHom ι κ μ (1, 1, sμ)
+      = (Equiv.sumAssoc ι κ μ).permCongr (Equiv.sumCongr (1 : Equiv.Perm (ι ⊕ κ)) sμ) := by
+  rw [youngHom_apply]
+  ext x; rcases x with i | j | k <;> simp [Equiv.permCongr_apply]
+
+/-- Forget the `ι`/`κ` split: the projection `T ι κ μ → ModSumCongr (ι ⊕ κ) μ` (via `sumAssoc`). -/
+def projAssocR : T ι κ μ → Equiv.Perm.ModSumCongr (ι ⊕ κ) μ :=
+  fun q => Quotient.liftOn' q
+    (fun A => (Quotient.mk'' ((Equiv.sumAssoc ι κ μ).symm.permCongr A) :
+      Equiv.Perm.ModSumCongr (ι ⊕ κ) μ)) (by
+    intro A₁ A₂ hA
+    rw [QuotientGroup.leftRel_apply] at hA
+    obtain ⟨⟨sι, sκ, sμ⟩, h⟩ := hA
+    have hA₂ : A₂ = A₁ * Equiv.sumCongr sι (Equiv.sumCongr sκ sμ) :=
+      eq_mul_of_inv_mul_eq h.symm
+    apply Quotient.sound'
+    rw [QuotientGroup.leftRel_apply]
+    refine ⟨(Equiv.sumCongr sι sκ, sμ), ?_⟩
+    simp only [Equiv.Perm.sumCongrHom_apply, hA₂, permCongr_mul, permCongr_sumAssoc_symm_young]
+    rw [inv_mul_cancel_left])
+
+@[simp] theorem projAssocR_mk (A : Equiv.Perm (ι ⊕ κ ⊕ μ)) :
+    projAssocR (Quotient.mk'' A) =
+      (Quotient.mk'' ((Equiv.sumAssoc ι κ μ).symm.permCongr A) :
+        Equiv.Perm.ModSumCongr (ι ⊕ κ) μ) := rfl
+
+/-- Insert an `ι`/`κ` split `π` into the left block, fibrewise over `projAssocR`. -/
+def fibAssocR (τ : Equiv.Perm ((ι ⊕ κ) ⊕ μ)) : Equiv.Perm.ModSumCongr ι κ → T ι κ μ :=
+  fun r => Quotient.liftOn' r
+    (fun π => Quotient.mk''
+      ((Equiv.sumAssoc ι κ μ).permCongr (τ * Equiv.sumCongr π (1 : Equiv.Perm μ)))) (by
+    intro π₁ π₂ hπ
+    rw [QuotientGroup.leftRel_apply] at hπ
+    obtain ⟨⟨sι, sκ⟩, h⟩ := hπ
+    apply Quotient.sound'
+    rw [QuotientGroup.leftRel_apply]
+    refine ⟨(sι, sκ, 1), ?_⟩
+    have hkey : (τ * Equiv.sumCongr π₁ (1 : Equiv.Perm μ))⁻¹ *
+          (τ * Equiv.sumCongr π₂ (1 : Equiv.Perm μ))
+        = Equiv.sumCongr (Equiv.sumCongr sι sκ) (1 : Equiv.Perm μ) := by
+      rw [mul_inv_rev, mul_assoc, inv_mul_cancel_left, Equiv.Perm.sumCongr_inv, inv_one,
+        Equiv.Perm.sumCongr_mul, one_mul, ← h, Equiv.Perm.sumCongrHom_apply]
+    rw [youngHom_apply, ← permCongr_sumAssoc_young sι sκ 1, ← hkey, ← permCongr_inv,
+      ← permCongr_mul])
+
+@[simp] theorem fibAssocR_mk (τ : Equiv.Perm ((ι ⊕ κ) ⊕ μ)) (π : Equiv.Perm (ι ⊕ κ)) :
+    fibAssocR τ (Quotient.mk'' π) =
+      Quotient.mk'' ((Equiv.sumAssoc ι κ μ).permCongr (τ * Equiv.sumCongr π (1 : Equiv.Perm μ))) :=
+  rfl
+
+/-- The per-fibre identity for the RHS (left) fibration. -/
+theorem rcore_fiber (a : E [⋀^ι]→L[𝕜] 𝕜) (b : E [⋀^κ]→L[𝕜] 𝕜) (c : E [⋀^μ]→L[𝕜] 𝕜)
+    (v : ι ⊕ κ ⊕ μ → E) (τ : Equiv.Perm ((ι ⊕ κ) ⊕ μ)) :
+    uncurrySum.summand ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂
+        (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ a b)) c)
+        (Quotient.mk'' τ) (v ∘ ⇑(Equiv.sumAssoc ι κ μ))
+      = ∑ A ∈ Finset.univ.filter (fun q : T ι κ μ => projAssocR q = Quotient.mk'' τ),
+          tterm a b c v A := by
+  rw [summand_mk_eval]
+  simp only [ContinuousLinearMap.compContinuousAlternatingMap₂_apply, ContinuousLinearMap.mul_apply']
+  rw [uncurrySum_mul_apply, Finset.sum_mul, Finset.smul_sum]
+  refine Finset.sum_bij (fun (r : Equiv.Perm.ModSumCongr ι κ) _ => fibAssocR τ r) ?_ ?_ ?_ ?_
+  · -- maps into the fibre
+    intro r _
+    induction r using Quotient.inductionOn' with
+    | _ π =>
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and, fibAssocR_mk, projAssocR_mk,
+        permCongr_symm_permCongr]
+      apply Quotient.sound'
+      rw [QuotientGroup.leftRel_apply]
+      refine ⟨(π⁻¹, 1), ?_⟩
+      rw [Equiv.Perm.sumCongrHom_apply, mul_inv_rev, mul_assoc, inv_mul_cancel, mul_one,
+        Equiv.Perm.sumCongr_inv, inv_one]
+  · -- injective
+    intro r₁ _ r₂ _ heq
+    induction r₁ using Quotient.inductionOn' with
+    | _ π₁ =>
+    induction r₂ using Quotient.inductionOn' with
+    | _ π₂ =>
+      simp only [fibAssocR_mk] at heq
+      rw [Quotient.eq'', QuotientGroup.leftRel_apply] at heq ⊢
+      obtain ⟨⟨sι, sκ, sμ⟩, h⟩ := heq
+      rw [youngHom_apply, ← permCongr_inv, ← permCongr_mul,
+        show (τ * Equiv.sumCongr π₁ (1 : Equiv.Perm μ))⁻¹ *
+            (τ * Equiv.sumCongr π₂ (1 : Equiv.Perm μ))
+          = Equiv.sumCongr (π₁⁻¹ * π₂) (1 : Equiv.Perm μ) from by
+          rw [mul_inv_rev, mul_assoc, inv_mul_cancel_left, Equiv.Perm.sumCongr_inv, inv_one,
+            Equiv.Perm.sumCongr_mul, one_mul]] at h
+      have h2 := congrArg (Equiv.sumAssoc ι κ μ).symm.permCongr h
+      rw [permCongr_sumAssoc_symm_young, permCongr_symm_permCongr] at h2
+      have hX : Equiv.sumCongr sι sκ = π₁⁻¹ * π₂ := by
+        ext x
+        have := congrArg (fun e => e (Sum.inl x)) h2
+        simpa using this
+      exact ⟨(sι, sκ), by simp only [Equiv.Perm.sumCongrHom_apply]; exact hX⟩
+  · -- surjective
+    intro b hb
+    induction b using Quotient.inductionOn' with
+    | _ A =>
+      rw [Finset.mem_filter] at hb
+      have hcl : (Quotient.mk'' ((Equiv.sumAssoc ι κ μ).symm.permCongr A) :
+          Equiv.Perm.ModSumCongr (ι ⊕ κ) μ) = Quotient.mk'' τ := by
+        have := hb.2; rwa [projAssocR_mk] at this
+      rw [Quotient.eq'', QuotientGroup.leftRel_apply] at hcl
+      have hcl' : τ⁻¹ * ((Equiv.sumAssoc ι κ μ).symm.permCongr A)
+          ∈ (Equiv.Perm.sumCongrHom (ι ⊕ κ) μ).range := by
+        have := (Equiv.Perm.sumCongrHom (ι ⊕ κ) μ).range.inv_mem hcl
+        rwa [mul_inv_rev, inv_inv] at this
+      obtain ⟨⟨π, sμ⟩, hπ⟩ := hcl'
+      simp only [Equiv.Perm.sumCongrHom_apply] at hπ
+      have hB : (Equiv.sumAssoc ι κ μ).symm.permCongr A = τ * Equiv.sumCongr π sμ :=
+        eq_mul_of_inv_mul_eq hπ.symm
+      refine ⟨Quotient.mk'' π, Finset.mem_univ _, ?_⟩
+      simp only [fibAssocR_mk]
+      apply Quotient.sound'
+      rw [QuotientGroup.leftRel_apply]
+      refine ⟨(1, 1, sμ), ?_⟩
+      have hAeq : A = (Equiv.sumAssoc ι κ μ).permCongr (τ * Equiv.sumCongr π sμ) := by
+        rw [← hB, permCongr_permCongr_symm]
+      have hinner : (τ * Equiv.sumCongr π (1 : Equiv.Perm μ))⁻¹ * (τ * Equiv.sumCongr π sμ)
+          = Equiv.sumCongr (1 : Equiv.Perm (ι ⊕ κ)) sμ := by
+        rw [mul_inv_rev, mul_assoc, inv_mul_cancel_left, Equiv.Perm.sumCongr_inv, inv_one,
+          Equiv.Perm.sumCongr_mul, one_mul, inv_mul_cancel]
+      rw [youngHom_one_one, hAeq, ← permCongr_inv, ← permCongr_mul]
+      exact congrArg _ hinner.symm
+  · -- term identity
+    intro r _
+    induction r using Quotient.inductionOn' with
+    | _ π =>
+      have hsign : Equiv.Perm.sign ((Equiv.sumAssoc ι κ μ).permCongr
+            (τ * Equiv.sumCongr π (1 : Equiv.Perm μ)))
+          = Equiv.Perm.sign τ * Equiv.Perm.sign π := by
+        rw [Equiv.Perm.sign_permCongr, map_mul, Equiv.Perm.sign_sumCongr, map_one, mul_one]
+      simp only [fibAssocR_mk, tterm_mk, ttermFun, mul_summand_eval', hsign,
+        Equiv.permCongr_apply, Equiv.sumAssoc_symm_apply_inl, Equiv.sumAssoc_symm_apply_inr_inl,
+        Equiv.sumAssoc_symm_apply_inr_inr, Equiv.Perm.mul_apply, Equiv.sumCongr_apply, Sum.map_inl,
+        Sum.map_inr, Equiv.Perm.coe_one, id_eq, Function.comp_apply, smul_mul_assoc,
+        mul_smul_comm, smul_smul, mul_assoc]
+
+/-- **RHS core = sum over the triple quotient** (left fibration over `projAssocR`, via `sumAssoc`). -/
+theorem rcore_eq_sumT (a : E [⋀^ι]→L[𝕜] 𝕜) (b : E [⋀^κ]→L[𝕜] 𝕜) (c : E [⋀^μ]→L[𝕜] 𝕜)
+    (v : ι ⊕ κ ⊕ μ → E) :
+    domDomCongr (Equiv.sumAssoc ι κ μ)
+        (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂
+          (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ a b)) c)) v
+      = ∑ q : T ι κ μ, tterm a b c v q := by
+  rw [domDomCongr_apply, uncurrySum_apply, ContinuousMultilinearMap.sum_apply,
+    ← Finset.sum_fiberwise Finset.univ projAssocR (tterm a b c v)]
+  refine Finset.sum_congr rfl fun τ' _ => ?_
+  induction τ' using Quotient.inductionOn' with
+  | _ τ => exact rcore_fiber a b c v τ
+
+/-- **Abstract associativity of the alternatization shuffle product.** -/
+theorem core_assoc (a : E [⋀^ι]→L[𝕜] 𝕜) (b : E [⋀^κ]→L[𝕜] 𝕜) (c : E [⋀^μ]→L[𝕜] 𝕜) :
+    uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ a
+        (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ b c)))
+      = domDomCongr (Equiv.sumAssoc ι κ μ)
+        (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂
+          (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ a b)) c)) := by
+  ext v
+  rw [lcore_eq_sumT, rcore_eq_sumT]
+
+end core
+
+/-! ### Pullout lemmas: reindexing a wedge factor commutes with `uncurrySum` -/
+
+section pullout
+
+variable {ι₁ ι₂ ν₁ ν₂ : Type*} [Fintype ι₁] [Fintype ι₂] [Fintype ν₁] [Fintype ν₂]
+  [DecidableEq ι₁] [DecidableEq ι₂] [DecidableEq ν₁] [DecidableEq ν₂]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+
+theorem permCongr_sumCongr (eL : ι₁ ≃ ι₂) (eR : ν₁ ≃ ν₂) (s₁ : Equiv.Perm ι₁) (s₂ : Equiv.Perm ν₁) :
+    (Equiv.sumCongr eL eR).permCongr (Equiv.sumCongr s₁ s₂)
+      = Equiv.sumCongr (eL.permCongr s₁) (eR.permCongr s₂) := by
+  ext x; rcases x with i | j <;> simp [Equiv.permCongr_apply]
+
+open Equiv.Perm in
+theorem mscCongr_spec (eL : ι₁ ≃ ι₂) (eR : ν₁ ≃ ν₂) (a b : Equiv.Perm (ι₁ ⊕ ν₁))
+    (h : (QuotientGroup.leftRel (Equiv.Perm.sumCongrHom ι₁ ν₁).range) a b) :
+    (Quot.mk _ ∘ (Equiv.sumCongr eL eR).permCongr) a
+      = (Quot.mk (⇑(QuotientGroup.leftRel (sumCongrHom ι₂ ν₂).range))
+          ∘ (Equiv.sumCongr eL eR).permCongr) b := by
+  apply Quot.sound
+  rw [QuotientGroup.leftRel_apply] at h ⊢
+  obtain ⟨⟨s₁, s₂⟩, hab⟩ := h
+  refine ⟨(eL.permCongr s₁, eR.permCongr s₂), ?_⟩
+  have hab' : Equiv.sumCongr s₁ s₂ = a⁻¹ * b := hab
+  simp only [Equiv.Perm.sumCongrHom_apply]
+  rw [← permCongr_inv, ← permCongr_mul, ← hab', permCongr_sumCongr]
+
+/-- Relabel both blocks of a `ModSumCongr` quotient by equivs. -/
+def mscCongr (eL : ι₁ ≃ ι₂) (eR : ν₁ ≃ ν₂) :
+    Equiv.Perm.ModSumCongr ι₁ ν₁ ≃ Equiv.Perm.ModSumCongr ι₂ ν₂ where
+  toFun := Quot.lift (Quot.mk _ ∘ (Equiv.sumCongr eL eR).permCongr) (mscCongr_spec eL eR)
+  invFun := Quot.lift (Quot.mk _ ∘ (Equiv.sumCongr eL.symm eR.symm).permCongr)
+    (mscCongr_spec eL.symm eR.symm)
+  left_inv := by rintro ⟨σ⟩; simp [← Equiv.sumCongr_symm]
+  right_inv := by rintro ⟨σ⟩; simp [← Equiv.sumCongr_symm]
+
+@[simp] theorem mscCongr_mk (eL : ι₁ ≃ ι₂) (eR : ν₁ ≃ ν₂) (σ : Equiv.Perm (ι₁ ⊕ ν₁)) :
+    mscCongr eL eR (Quotient.mk'' σ) = Quotient.mk'' ((Equiv.sumCongr eL eR).permCongr σ) := rfl
+
+/-- Reindexing the **right** factor of a scalar wedge by `e` commutes with `uncurrySum`,
+producing a `sumCongr (refl) e` reindex of the whole. -/
+theorem pullout_right (g : E [⋀^ι₁]→L[𝕜] 𝕜) (X : E [⋀^ν₁]→L[𝕜] 𝕜) (e : ν₁ ≃ ν₂) :
+    uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ g (domDomCongr e X))
+      = domDomCongr (Equiv.sumCongr (Equiv.refl ι₁) e)
+        (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ g X)) := by
+  ext w
+  rw [domDomCongr_apply, uncurrySum_apply, uncurrySum_apply,
+    ContinuousMultilinearMap.sum_apply, ContinuousMultilinearMap.sum_apply]
+  refine (Fintype.sum_equiv (mscCongr (Equiv.refl ι₁) e)
+    (fun σ' => uncurrySum.summand
+      ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ g X) σ'
+      (w ∘ ⇑(Equiv.sumCongr (Equiv.refl ι₁) e)))
+    (fun σ => uncurrySum.summand
+      ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ g (domDomCongr e X)) σ w)
+    ?_).symm
+  intro σ'
+  induction σ' using Quotient.inductionOn' with
+  | _ σ =>
+    simp only [mscCongr_mk, mul_summand_eval', Equiv.Perm.sign_permCongr, domDomCongr_apply,
+      Equiv.permCongr_apply, Equiv.sumCongr_apply, Equiv.sumCongr_symm, Equiv.refl_symm,
+      Sum.map_inl, Sum.map_inr, Equiv.refl_apply, Equiv.symm_apply_apply, Function.comp_apply,
+      Function.comp_def]
+
+/-- Reindexing the **left** factor of a scalar wedge by `e` commutes with `uncurrySum`. -/
+theorem pullout_left (X : E [⋀^ι₁]→L[𝕜] 𝕜) (c : E [⋀^ν₁]→L[𝕜] 𝕜) (e : ι₁ ≃ ι₂) :
+    uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ (domDomCongr e X) c)
+      = domDomCongr (Equiv.sumCongr e (Equiv.refl ν₁))
+        (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ X c)) := by
+  ext w
+  rw [domDomCongr_apply, uncurrySum_apply, uncurrySum_apply,
+    ContinuousMultilinearMap.sum_apply, ContinuousMultilinearMap.sum_apply]
+  refine (Fintype.sum_equiv (mscCongr e (Equiv.refl ν₁))
+    (fun σ' => uncurrySum.summand
+      ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ X c) σ'
+      (w ∘ ⇑(Equiv.sumCongr e (Equiv.refl ν₁))))
+    (fun σ => uncurrySum.summand
+      ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ (domDomCongr e X) c) σ w)
+    ?_).symm
+  intro σ'
+  induction σ' using Quotient.inductionOn' with
+  | _ σ =>
+    simp only [mscCongr_mk, mul_summand_eval', Equiv.Perm.sign_permCongr, domDomCongr_apply,
+      Equiv.permCongr_apply, Equiv.sumCongr_apply, Equiv.sumCongr_symm, Equiv.refl_symm,
+      Sum.map_inl, Sum.map_inr, Equiv.refl_apply, Equiv.symm_apply_apply, Function.comp_apply,
+      Function.comp_def]
+
+end pullout
+
+/-! ### Assembly: associativity of the wedge product -/
+
+section assemble
+
+variable {N N' N'' : Type*} [NormedAddCommGroup N] [NormedSpace 𝕜 N]
+  [NormedAddCommGroup N'] [NormedSpace 𝕜 N'] [NormedAddCommGroup N''] [NormedSpace 𝕜 N'']
+  {a b : ℕ}
+
+/-- Unfold the wedge as `domDomCongr finSumFinEquiv ∘ uncurrySum ∘ compCAM₂`. -/
+theorem wedge_eq_dDC (g : M [⋀^Fin a]→L[𝕜] N) (h : M [⋀^Fin b]→L[𝕜] N')
+    (f : N →L[𝕜] N' →L[𝕜] N'') :
+    wedge_product g h f
+      = domDomCongr finSumFinEquiv (uncurrySum (f.compContinuousAlternatingMap₂ g h)) := rfl
+
+/-- **Associativity of the wedge product** (CAM level). -/
+theorem wedge_mul_assoc' (g : M [⋀^Fin m]→L[𝕜] 𝕜) (h : M [⋀^Fin n]→L[𝕜] 𝕜)
+    (l : M [⋀^Fin p]→L[𝕜] 𝕜) :
+    domDomCongr finAssoc.symm (g ∧[𝕜] h ∧[𝕜] l) = (g ∧[𝕜] h) ∧[𝕜] l := by
+  have hL : (g ∧[𝕜] h ∧[𝕜] l)
+      = domDomCongr ((Equiv.sumCongr (Equiv.refl (Fin m)) finSumFinEquiv).trans finSumFinEquiv)
+        (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ g
+          (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ h l)))) := by
+    rw [wedge_eq_dDC g (h ∧[𝕜] l) (ContinuousLinearMap.mul 𝕜 𝕜), wedge_eq_dDC h l,
+      pullout_right, domDomCongr_domDomCongr]
+  have hR : ((g ∧[𝕜] h) ∧[𝕜] l)
+      = domDomCongr ((Equiv.sumCongr finSumFinEquiv (Equiv.refl (Fin p))).trans finSumFinEquiv)
+        (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂
+          (uncurrySum ((ContinuousLinearMap.mul 𝕜 𝕜).compContinuousAlternatingMap₂ g h)) l)) := by
+    rw [wedge_eq_dDC (g ∧[𝕜] h) l (ContinuousLinearMap.mul 𝕜 𝕜), wedge_eq_dDC g h,
+      pullout_left, domDomCongr_domDomCongr]
+  rw [hL, hR, domDomCongr_domDomCongr, core_assoc, domDomCongr_domDomCongr]
+  have heq : (Equiv.sumAssoc (Fin m) (Fin n) (Fin p)).trans
+        (((Equiv.sumCongr (Equiv.refl (Fin m)) finSumFinEquiv).trans finSumFinEquiv).trans
+          finAssoc.symm)
+      = (Equiv.sumCongr finSumFinEquiv (Equiv.refl (Fin p))).trans finSumFinEquiv :=
+    (eR3_eq_sumAssoc_eL3).symm
+  rw [heq]
+
+end assemble
+
+/-- **Associativity of the multiplication wedge product** (the thesis's Prop. 4.27). -/
+theorem wedge_mul_assoc (g : M [⋀^Fin m]→L[𝕜] 𝕜) (h : M [⋀^Fin n]→L[𝕜] 𝕜)
+    (l : M [⋀^Fin p]→L[𝕜] 𝕜) (v : Fin (m + n + p) → M) :
+    ContinuousAlternatingMap.domDomCongr finAssoc.symm (g ∧[𝕜] h ∧[𝕜] l) v
+      = ((g ∧[𝕜] h) ∧[𝕜] l) v :=
+  congrFun (congrArg _ (wedge_mul_assoc' g h l)) v
+
+end ContinuousAlternatingMap
+

--- a/DeRhamCohomology/ContinuousAlternatingMap/WedgeFDeriv.lean
+++ b/DeRhamCohomology/ContinuousAlternatingMap/WedgeFDeriv.lean
@@ -811,6 +811,519 @@ theorem uncurryFin_precompR_wedge (f : N →L[𝕜] N' →L[𝕜] N'')
     rw [pow_mul, neg_one_sq, one_pow]
   rw [show m + m * (n + 1) = m * n + 2 * m by ring, pow_add, h2, mul_one]
 
+
+/-! ### The interior-product (slot-0 contraction) Leibniz rule -/
+
+-- claim (b): right slots.
+theorem claim_b (σ' : Equiv.Perm (Fin m ⊕ Fin (n + 1))) (x₀ : E) (y : Fin (m + (n + 1)) → E) :
+    (fun j => ((Fin.cons x₀ y ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv)
+        (insPerm (0 : Fin (m + (n + 1) + 1)) σ' (Sum.inr j)))
+      = (fun j => y (finSumFinEquiv (σ' (Sum.inr j)))) := by
+  funext j
+  show (Fin.cons x₀ y : Fin _ → E)
+      (insSumEquiv (insPerm (0 : Fin (m + (n + 1) + 1)) σ' (Sum.inr j))) = _
+  rw [insPerm, Equiv.trans_apply, Equiv.apply_symm_apply, insHat_inr, Fin.succAbove_zero,
+    Fin.cons_succ]
+
+-- claim (a): left slots.
+theorem claim_a (σ' : Equiv.Perm (Fin m ⊕ Fin (n + 1))) (x₀ : E) (y : Fin (m + (n + 1)) → E) :
+    (fun i => ((Fin.cons x₀ y ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv)
+        (insPerm (0 : Fin (m + (n + 1) + 1)) σ' (Sum.inl i)))
+      = (Fin.cons x₀ (fun i => y (finSumFinEquiv (σ' (Sum.inl i)))) : Fin _ → E) := by
+  funext i
+  show (Fin.cons x₀ y : Fin _ → E)
+      (insSumEquiv (insPerm (0 : Fin (m + (n + 1) + 1)) σ' (Sum.inl i))) = _
+  rw [insPerm, Equiv.trans_apply, Equiv.apply_symm_apply]
+  induction i using Fin.cases with
+  | zero => rw [insHat_inl_zero, Fin.cons_zero, Fin.cons_zero]
+  | succ k => rw [insHat_inl_succ, Fin.succAbove_zero, Fin.cons_succ, Fin.cons_succ]
+
+/-- Which factor the contracted slot `inl 0` feeds into, as a class invariant. -/
+def isLeftClass : Equiv.Perm.ModSumCongr (Fin (m + 1)) (Fin (n + 1)) → Bool :=
+  fun q => Quotient.liftOn' q (fun σ => (σ⁻¹ (Sum.inl 0)).isLeft) (by
+    intro a b hab
+    rw [QuotientGroup.leftRel_apply] at hab
+    obtain ⟨⟨sl, sr⟩, hb⟩ := hab
+    simp only [Equiv.Perm.sumCongrHom_apply] at hb
+    have hbb : b = a * Equiv.sumCongr sl sr := by
+      rw [show Equiv.sumCongr sl sr = sl.sumCongr sr from rfl, hb, mul_inv_cancel_left]
+    rw [hbb]
+    simp only [mul_inv_rev, Equiv.Perm.coe_mul, Function.comp_apply]
+    rcases h0 : a⁻¹ (Sum.inl 0) with i | j <;>
+      simp [Equiv.sumCongr_symm, Equiv.sumCongr_apply, h0])
+
+theorem summandA (g : E [⋀^Fin (m + 1)]→L[𝕜] N) (h : E [⋀^Fin (n + 1)]→L[𝕜] N')
+    (f : N →L[𝕜] N' →L[𝕜] N'') (x₀ : E) (y : Fin (m + (n + 1)) → E)
+    (σ' : Equiv.Perm (Fin m ⊕ Fin (n + 1))) :
+    uncurrySum.summand (f.compContinuousAlternatingMap₂ g h)
+        (Quotient.mk'' (insPerm (0 : Fin (m + (n + 1) + 1)) σ'))
+        ((Fin.cons x₀ y ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv)
+      = uncurrySum.summand (f.compContinuousAlternatingMap₂ (curryFin g x₀) h)
+        (Quotient.mk'' σ') (y ∘ ⇑finSumFinEquiv) := by
+  rw [summand_mk_eval, summand_mk_eval, sign_insPerm_zero]
+  congr 1
+  rw [ContinuousLinearMap.compContinuousAlternatingMap₂_apply,
+    ContinuousLinearMap.compContinuousAlternatingMap₂_apply, curryFin_apply,
+    claim_a σ' x₀ y, claim_b σ' x₀ y]
+  rfl
+
+-- Identity 1 (Part A): the left-classes reconstruct term1.
+theorem identityA (g : E [⋀^Fin (m + 1)]→L[𝕜] N) (h : E [⋀^Fin (n + 1)]→L[𝕜] N')
+    (f : N →L[𝕜] N' →L[𝕜] N'') (x₀ : E) (y : Fin (m + (n + 1)) → E) :
+    ∑ σ' : Equiv.Perm.ModSumCongr (Fin m) (Fin (n + 1)),
+        uncurrySum.summand (f.compContinuousAlternatingMap₂ (curryFin g x₀) h) σ'
+          (y ∘ ⇑finSumFinEquiv)
+      = ∑ σ ∈ Finset.univ.filter (fun q => isLeftClass q = true),
+        uncurrySum.summand (f.compContinuousAlternatingMap₂ g h) σ
+          ((Fin.cons x₀ y ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv) := by
+  refine Finset.sum_bij (fun σ' _ => proj (0, σ')) ?_ ?_ ?_ ?_
+  · -- maps into the left-classes
+    intro a _
+    rw [Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    induction a using Quotient.inductionOn' with
+    | _ σ =>
+      have key : (insPerm (0 : Fin (m + (n + 1) + 1)) σ)⁻¹ (Sum.inl 0) = Sum.inl 0 := by
+        rw [Equiv.Perm.inv_eq_iff_eq]; symm
+        rw [insPerm, Equiv.trans_apply, insHat_inl_zero,
+          show (0 : Fin (m + (n + 1) + 1)) = insSumEquiv (Sum.inl 0) from insSumEquiv_inl_zero.symm,
+          Equiv.symm_apply_apply]
+      simp only [proj_mk, isLeftClass, Quotient.liftOn'_mk'', key, Sum.isLeft_inl]
+  · -- injective
+    intro a₁ _ a₂ _ heq
+    induction a₁ using Quotient.inductionOn' with
+    | _ σ₁ =>
+    induction a₂ using Quotient.inductionOn' with
+    | _ σ₂ =>
+      simp only [proj_mk] at heq
+      exact proj_left_injective 0 σ₁ σ₂ heq
+  · -- surjective onto left-classes
+    intro b hb
+    rw [Finset.mem_filter] at hb
+    induction b using Quotient.inductionOn' with
+    | _ τ =>
+      rcases h0 : τ⁻¹ (Sum.inl 0) with i₀ | j₀
+      · refine ⟨Quotient.mk'' (restPerm τ i₀), Finset.mem_univ _, ?_⟩
+        have hτ : τ (Sum.inl i₀) = Sum.inl 0 := by rw [← h0, Equiv.Perm.apply_inv_self]
+        have hmark : markedOut τ i₀ = 0 := by rw [markedOut, hτ, insSumEquiv_inl_zero]
+        simp only [proj_mk]
+        rw [← hmark, insPerm_markedOut_restPerm, Quotient.eq'', QuotientGroup.leftRel_apply]
+        refine ⟨(i₀.cycleRange, Equiv.refl (Fin (n + 1))), ?_⟩
+        simp only [Equiv.Perm.sumCongrHom_apply]
+        have hg : (τ * slotMove i₀)⁻¹ * τ = (slotMove i₀)⁻¹ := by group
+        rw [hg, slotMove_inv]
+      · have hb2 := hb.2
+        simp only [isLeftClass, Quotient.liftOn'_mk'', h0, Sum.isLeft_inr,
+          Bool.false_eq_true] at hb2
+  · -- term identity
+    intro a _
+    induction a using Quotient.inductionOn' with
+    | _ σ' => simp only [proj_mk]; exact (summandA g h f x₀ y σ').symm
+
+/- ===================== Part B: right-block insertion ===================== -/
+
+/-- `Fin (m+1) ⊕ Option (Fin n) ≃ Option (Fin (m+1) ⊕ Fin n)`. -/
+def optSumR : Fin (m + 1) ⊕ Option (Fin n) ≃ Option (Fin (m + 1) ⊕ Fin n) where
+  toFun := Sum.elim (fun i => some (Sum.inl i)) (fun o => o.map Sum.inr)
+  invFun := fun o => o.elim (Sum.inr none) (Sum.elim Sum.inl (fun j => Sum.inr (some j)))
+  left_inv := by rintro (i | (_ | j)) <;> rfl
+  right_inv := by rintro (_ | (i | j)) <;> rfl
+
+@[simp] theorem optSumR_inl (i : Fin (m + 1)) :
+    (optSumR (n := n)) (Sum.inl i) = some (Sum.inl i) := rfl
+@[simp] theorem optSumR_inr_none : (optSumR (m := m) (n := n)) (Sum.inr none) = none := rfl
+@[simp] theorem optSumR_inr_some (j : Fin n) :
+    (optSumR (m := m)) (Sum.inr (some j)) = some (Sum.inr j) := rfl
+
+theorem fse0_symm_some {p : ℕ} (j : Fin p) :
+    (finSuccEquiv' (0 : Fin (p + 1))).symm (some j) = j.succ := by
+  rw [finSuccEquiv'_symm_some, Fin.succAbove_zero]
+theorem fse0_symm_none {p : ℕ} : (finSuccEquiv' (0 : Fin (p + 1))).symm none = 0 :=
+  finSuccEquiv'_symm_none 0
+theorem fse0_succ {p : ℕ} (j : Fin p) : (finSuccEquiv' (0 : Fin (p + 1))) j.succ = some j := by
+  rw [← Fin.succAbove_zero (n := p), finSuccEquiv'_succAbove]
+
+/-- Drop the marked slot `inr 0` from the right block. -/
+def dropR : Fin (m + 1) ⊕ Fin (n + 1) ≃ Option (Fin (m + 1) ⊕ Fin n) :=
+  (Equiv.sumCongr (Equiv.refl (Fin (m + 1))) (finSuccEquiv' 0)).trans optSumR
+
+@[simp] theorem dropR_inl (i : Fin (m + 1)) : (dropR (n := n)) (Sum.inl i) = some (Sum.inl i) := by
+  simp [dropR]
+@[simp] theorem dropR_inr_zero : (dropR (m := m) (n := n)) (Sum.inr 0) = none := by
+  simp [dropR]
+@[simp] theorem dropR_inr_succ (j : Fin n) :
+    (dropR (m := m)) (Sum.inr j.succ) = some (Sum.inr j) := by
+  simp only [dropR, Equiv.trans_apply, Equiv.sumCongr_apply, Sum.map_inr, fse0_succ,
+    optSumR_inr_some]
+
+@[simp] theorem dropR_symm_none : (dropR (m := m) (n := n)).symm none = Sum.inr 0 :=
+  dropR.symm_apply_eq.mpr dropR_inr_zero.symm
+@[simp] theorem dropR_symm_some_inl (i : Fin (m + 1)) :
+    (dropR (n := n)).symm (some (Sum.inl i)) = Sum.inl i :=
+  dropR.symm_apply_eq.mpr (dropR_inl i).symm
+@[simp] theorem dropR_symm_some_inr (j : Fin n) :
+    (dropR (m := m)).symm (some (Sum.inr j)) = Sum.inr j.succ :=
+  dropR.symm_apply_eq.mpr (dropR_inr_succ j).symm
+
+/-- Insert the marked slot `inr 0 ↦ output 0`, laying out the rest of `b` past output 0. -/
+def insHatR (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) :
+    Fin (m + 1) ⊕ Fin (n + 1) ≃ Fin (m + 1 + (n + 1)) :=
+  dropR.trans <| (Equiv.optionCongr b).trans <|
+    (Equiv.optionCongr finSumFinEquiv).trans (finSuccEquiv' 0).symm
+
+theorem insHatR_inr_zero (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) :
+    insHatR b (Sum.inr 0) = 0 := by
+  simp only [insHatR, Equiv.trans_apply, dropR_inr_zero, Equiv.optionCongr_apply, Option.map_none]
+  exact fse0_symm_none
+
+theorem insHatR_inl (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (i : Fin (m + 1)) :
+    insHatR b (Sum.inl i) = (finSumFinEquiv (b (Sum.inl i))).succ := by
+  simp only [insHatR, Equiv.trans_apply, dropR_inl, Equiv.optionCongr_apply, Option.map_some]
+  exact fse0_symm_some _
+
+theorem insHatR_inr_succ (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (j : Fin n) :
+    insHatR b (Sum.inr j.succ) = (finSumFinEquiv (b (Sum.inr j))).succ := by
+  simp only [insHatR, Equiv.trans_apply, dropR_inr_succ, Equiv.optionCongr_apply, Option.map_some]
+  exact fse0_symm_some _
+
+/-- Right-block insertion as a permutation. -/
+def insPermR (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) : Equiv.Perm (Fin (m + 1) ⊕ Fin (n + 1)) :=
+  (insHatR b).trans finSumFinEquiv.symm
+
+theorem insPermR_inr_zero (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) :
+    insPermR b (Sum.inr 0) = Sum.inl 0 := by
+  rw [insPermR, Equiv.trans_apply, insHatR_inr_zero, Equiv.symm_apply_eq]
+  apply Fin.ext; simp
+
+/- ---- sign of insPermR ---- -/
+
+/-- The within-block conjugate of `b` used to factor `insPermR b = insPermR 1 * liftR b`. -/
+def liftR (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) : Equiv.Perm (Fin (m + 1) ⊕ Fin (n + 1)) :=
+  dropR.trans ((Equiv.optionCongr b).trans dropR.symm)
+
+theorem insPermR_eq_mul (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) :
+    insPermR b = insPermR 1 * liftR b := by
+  ext x
+  simp only [insPermR, liftR, insHatR, Equiv.Perm.mul_apply, Equiv.trans_apply,
+    Equiv.apply_symm_apply, Equiv.optionCongr_apply, Equiv.Perm.coe_one, Option.map_id, id_eq]
+
+theorem sign_liftR (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) :
+    Equiv.Perm.sign (liftR b) = Equiv.Perm.sign b := by
+  rw [Equiv.Perm.sign_eq_sign_of_equiv (liftR b) (Equiv.optionCongr b) dropR ?_,
+    Equiv.optionCongr_sign]
+  intro x
+  simp only [liftR, Equiv.trans_apply, Equiv.apply_symm_apply]
+
+theorem sign_insPermR_one :
+    Equiv.Perm.sign (insPermR (1 : Equiv.Perm (Fin (m + 1) ⊕ Fin n))) = (-1) ^ (m + 1) := by
+  have hlt : m + 1 < m + 1 + (n + 1) := by omega
+  set c : Fin (m + 1 + (n + 1)) := ⟨m + 1, hlt⟩ with hc
+  have hsign : Equiv.Perm.sign (insPermR (1 : Equiv.Perm (Fin (m + 1) ⊕ Fin n)))
+      = Equiv.Perm.sign (Fin.cycleRange c) := by
+    refine Equiv.Perm.sign_eq_sign_of_equiv (insPermR 1) (Fin.cycleRange c) finSumFinEquiv ?_
+    intro x
+    have hfin : finSumFinEquiv (insPermR 1 x) = insHatR 1 x := by
+      rw [insPermR, Equiv.trans_apply, Equiv.apply_symm_apply]
+    rw [hfin]
+    rcases x with i | j
+    · rw [insHatR_inl, Equiv.Perm.one_apply, finSumFinEquiv_apply_left, finSumFinEquiv_apply_left]
+      have hji : Fin.castAdd (n + 1) i < c := by
+        rw [Fin.lt_iff_val_lt_val]; simp only [Fin.coe_castAdd, hc]; omega
+      rw [Fin.cycleRange_of_lt hji, ← Fin.castSucc_castAdd, Fin.coeSucc_eq_succ]
+    · induction j using Fin.cases with
+      | zero =>
+        rw [insHatR_inr_zero, finSumFinEquiv_apply_right]
+        have heq : Fin.natAdd (m + 1) (0 : Fin (n + 1)) = c := by
+          apply Fin.ext; simp only [Fin.coe_natAdd, hc, Fin.val_zero, Nat.add_zero]
+        rw [Fin.cycleRange_of_eq heq]
+      | succ k =>
+        rw [insHatR_inr_succ, Equiv.Perm.one_apply, finSumFinEquiv_apply_right,
+          finSumFinEquiv_apply_right]
+        have hgt : c < Fin.natAdd (m + 1) k.succ := by
+          rw [Fin.lt_iff_val_lt_val]; simp only [Fin.coe_natAdd, Fin.val_succ, hc]; omega
+        rw [Fin.cycleRange_of_gt hgt]
+        apply Fin.ext
+        simp only [Fin.val_succ, Fin.coe_natAdd]
+        omega
+  rw [hsign, Fin.sign_cycleRange]
+
+theorem sign_insPermR (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) :
+    Equiv.Perm.sign (insPermR b) = (-1) ^ (m + 1) * Equiv.Perm.sign b := by
+  rw [insPermR_eq_mul, map_mul, sign_insPermR_one, sign_liftR]
+
+/- ---- Part B term identity ---- -/
+
+theorem finSumFinEquiv_insPermR (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n))
+    (s : Fin (m + 1) ⊕ Fin (n + 1)) : finSumFinEquiv (insPermR b s) = insHatR b s := by
+  rw [insPermR, Equiv.trans_apply, Equiv.apply_symm_apply]
+
+theorem wB_inl (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (i : Fin (m + 1)) :
+    finAddFlipAssoc (finSumFinEquiv (insPermR b (Sum.inl i)))
+      = (finAddFlipAssoc (finSumFinEquiv (b (Sum.inl i)))).succ := by
+  apply Fin.ext
+  rw [finSumFinEquiv_insPermR, insHatR_inl]
+  simp only [finAddFlipAssoc, finCongr_apply, Fin.coe_cast, Fin.val_succ]
+
+theorem wB_inr_zero (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) :
+    finAddFlipAssoc (finSumFinEquiv (insPermR b (Sum.inr 0))) = 0 := by
+  apply Fin.ext
+  rw [finSumFinEquiv_insPermR, insHatR_inr_zero]
+  simp only [finAddFlipAssoc, finCongr_apply, Fin.coe_cast, Fin.val_zero]
+
+theorem wB_inr_succ (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (k : Fin n) :
+    finAddFlipAssoc (finSumFinEquiv (insPermR b (Sum.inr k.succ)))
+      = (finAddFlipAssoc (finSumFinEquiv (b (Sum.inr k)))).succ := by
+  apply Fin.ext
+  rw [finSumFinEquiv_insPermR, insHatR_inr_succ]
+  simp only [finAddFlipAssoc, finCongr_apply, Fin.coe_cast, Fin.val_succ]
+
+theorem claim_g_B (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (x₀ : E) (y : Fin (m + (n + 1)) → E) :
+    (fun i => ((Fin.cons x₀ y ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv) (insPermR b (Sum.inl i)))
+      = (fun i => ((y ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv) (b (Sum.inl i))) := by
+  funext i
+  simp only [Function.comp_apply]
+  rw [wB_inl, Fin.cons_succ]
+
+theorem claim_h_B (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (x₀ : E) (y : Fin (m + (n + 1)) → E) :
+    (fun j => ((Fin.cons x₀ y ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv) (insPermR b (Sum.inr j)))
+      = (Fin.cons x₀ (fun k => ((y ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv) (b (Sum.inr k))) : Fin _ → E) := by
+  funext j
+  simp only [Function.comp_apply]
+  induction j using Fin.cases with
+  | zero => rw [wB_inr_zero, Fin.cons_zero, Fin.cons_zero]
+  | succ k => rw [wB_inr_succ, Fin.cons_succ, Fin.cons_succ]
+
+theorem summandB (g : E [⋀^Fin (m + 1)]→L[𝕜] N) (h : E [⋀^Fin (n + 1)]→L[𝕜] N')
+    (f : N →L[𝕜] N' →L[𝕜] N'') (x₀ : E) (y : Fin (m + (n + 1)) → E)
+    (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) :
+    uncurrySum.summand (f.compContinuousAlternatingMap₂ g h) (Quotient.mk'' (insPermR b))
+        ((Fin.cons x₀ y ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv)
+      = (-1 : 𝕜) ^ (m + 1) • uncurrySum.summand (f.compContinuousAlternatingMap₂ g (curryFin h x₀))
+        (Quotient.mk'' b) ((y ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv) := by
+  rw [summand_mk_eval, summand_mk_eval,
+    ContinuousLinearMap.compContinuousAlternatingMap₂_apply,
+    ContinuousLinearMap.compContinuousAlternatingMap₂_apply, curryFin_apply,
+    claim_g_B, claim_h_B, sign_insPermR, mul_smul]
+  rw [Units.smul_def ((-1 : ℤˣ) ^ (m + 1)), Units.val_pow_eq_pow_val, Units.val_neg, Units.val_one,
+    ← Int.cast_smul_eq_zsmul 𝕜, Int.cast_pow, Int.cast_neg, Int.cast_one]
+
+/- ---- Part B descent + injectivity ---- -/
+
+theorem insPermR_mul_sumCongr (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n))
+    (sl : Equiv.Perm (Fin (m + 1))) (sr : Equiv.Perm (Fin n)) :
+    insPermR (b * Equiv.sumCongr sl sr)
+      = insPermR b * Equiv.sumCongr sl (Equiv.Perm.decomposeFin.symm (0, sr)) := by
+  ext z
+  rw [Equiv.Perm.mul_apply, insPermR, Equiv.trans_apply, insPermR, Equiv.trans_apply]
+  congr 1
+  rcases z with i | j
+  · rw [Equiv.sumCongr_apply, Sum.map_inl, insHatR_inl, insHatR_inl, Equiv.Perm.mul_apply,
+      Equiv.sumCongr_apply, Sum.map_inl]
+  · induction j using Fin.cases with
+    | zero =>
+      rw [Equiv.sumCongr_apply, Sum.map_inr, Equiv.Perm.decomposeFin_symm_apply_zero,
+        insHatR_inr_zero, insHatR_inr_zero]
+    | succ k =>
+      rw [Equiv.sumCongr_apply, Sum.map_inr, Equiv.Perm.decomposeFin_symm_apply_succ,
+        Equiv.swap_self, Equiv.refl_apply, insHatR_inr_succ, insHatR_inr_succ, Equiv.Perm.mul_apply,
+        Equiv.sumCongr_apply, Sum.map_inr]
+
+open Equiv.Perm in
+theorem projR_spec (a b : Equiv.Perm (Fin (m + 1) ⊕ Fin n))
+    (h : (QuotientGroup.leftRel (Equiv.Perm.sumCongrHom (Fin (m + 1)) (Fin n)).range) a b) :
+    (Quot.mk (⇑(QuotientGroup.leftRel (sumCongrHom (Fin (m + 1)) (Fin (n + 1))).range))
+        (insPermR a)) =
+      (Quot.mk (⇑(QuotientGroup.leftRel (sumCongrHom (Fin (m + 1)) (Fin (n + 1))).range))
+        (insPermR b)) := by
+  apply Quot.sound
+  rw [QuotientGroup.leftRel_apply] at h ⊢
+  obtain ⟨⟨sl, sr⟩, hb⟩ := h
+  simp only [sumCongrHom_apply, MonoidHom.coe_mk, OneHom.coe_mk] at hb
+  have hbb : b = a * Equiv.sumCongr sl sr := by
+    rw [show Equiv.sumCongr sl sr = sl.sumCongr sr from rfl, hb, mul_inv_cancel_left]
+  rw [hbb, insPermR_mul_sumCongr]
+  refine ⟨(sl, Equiv.Perm.decomposeFin.symm (0, sr)), ?_⟩
+  simp only [sumCongrHom_apply]
+  group
+
+/-- The descended right-block insertion `Q_B → Q`. -/
+def projR (q : Equiv.Perm.ModSumCongr (Fin (m + 1)) (Fin n)) :
+    Equiv.Perm.ModSumCongr (Fin (m + 1)) (Fin (n + 1)) :=
+  Quotient.liftOn' q (fun b => Quotient.mk'' (insPermR b)) projR_spec
+
+@[simp] theorem projR_mk (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) :
+    projR (Quotient.mk'' b) = Quotient.mk'' (insPermR b) := rfl
+
+theorem insHatR_injective (b : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) :
+    Function.Injective (insHatR b) := (insHatR b).injective
+
+theorem insPermR_left_injective :
+    Function.Injective (insPermR : Equiv.Perm (Fin (m + 1) ⊕ Fin n) → _) := by
+  intro b₁ b₂ h
+  have h' : insHatR b₁ = insHatR b₂ := by
+    have := congrArg (fun e => e.trans finSumFinEquiv) h
+    simpa only [insPermR, Equiv.symm_trans_self, Equiv.trans_refl, Equiv.trans_assoc] using this
+  ext z
+  rcases z with i | j
+  · have := Equiv.congr_fun h' (Sum.inl i)
+    rw [insHatR_inl, insHatR_inl] at this
+    exact finSumFinEquiv.injective (Fin.succ_injective _ this)
+  · have := Equiv.congr_fun h' (Sum.inr j.succ)
+    rw [insHatR_inr_succ, insHatR_inr_succ] at this
+    exact finSumFinEquiv.injective (Fin.succ_injective _ this)
+
+theorem projR_left_injective (b₁ b₂ : Equiv.Perm (Fin (m + 1) ⊕ Fin n))
+    (h : Quotient.mk'' (insPermR b₁) =
+      (Quotient.mk'' (insPermR b₂) : Equiv.Perm.ModSumCongr (Fin (m + 1)) (Fin (n + 1)))) :
+    (Quotient.mk'' b₁ : Equiv.Perm.ModSumCongr (Fin (m + 1)) (Fin n)) = Quotient.mk'' b₂ := by
+  rw [Quotient.eq'', QuotientGroup.leftRel_apply] at h
+  obtain ⟨⟨sl, sr⟩, hsl⟩ := h
+  simp only [Equiv.Perm.sumCongrHom_apply] at hsl
+  have hmul : insPermR b₂ = insPermR b₁ * Equiv.sumCongr sl sr := by
+    rw [show Equiv.sumCongr sl sr = sl.sumCongr sr from rfl, hsl, mul_inv_cancel_left]
+  -- evaluating at `inr 0` forces `sr 0 = 0`
+  have hsr0 : sr 0 = 0 := by
+    have e2 : insPermR b₂ (Sum.inr 0) = Sum.inl 0 := insPermR_inr_zero b₂
+    rw [hmul, Equiv.Perm.mul_apply, Equiv.sumCongr_apply, Sum.map_inr] at e2
+    have e1 : insPermR b₁ (Sum.inr 0) = Sum.inl 0 := insPermR_inr_zero b₁
+    exact Sum.inr_injective ((insPermR b₁).injective (e2.trans e1.symm))
+  set sr' := (Equiv.Perm.decomposeFin sr).2 with hsr'def
+  have hsr_eq : sr = Equiv.Perm.decomposeFin.symm (0, sr') := by
+    have hsplit : sr = Equiv.Perm.decomposeFin.symm (Equiv.Perm.decomposeFin sr) := by
+      rw [Equiv.symm_apply_apply]
+    have hp : (Equiv.Perm.decomposeFin sr).1 = 0 := by
+      have h0 : Equiv.Perm.decomposeFin.symm (Equiv.Perm.decomposeFin sr) 0 = sr 0 := by
+        rw [Equiv.symm_apply_apply]
+      rw [Equiv.Perm.decomposeFin_symm_apply_zero] at h0
+      rw [h0, hsr0]
+    rw [hsplit]; congr 1; rw [← hp]
+  rw [hsr_eq, ← insPermR_mul_sumCongr] at hmul
+  have hb := insPermR_left_injective hmul
+  rw [Quotient.eq'', QuotientGroup.leftRel_apply]
+  exact ⟨(sl, sr'), by simp only [Equiv.Perm.sumCongrHom_apply]; rw [hb]; group⟩
+
+/- ---- Part B surjectivity: restPermR ---- -/
+
+/-- Remove the marked slot `inr 0`/output `0` from a `τ'` with `τ' (inr 0) = inl 0`. -/
+def restOptR (τ' : Equiv.Perm (Fin (m + 1) ⊕ Fin (n + 1))) :
+    Option (Fin (m + 1) ⊕ Fin n) ≃ Option (Fin (m + 1 + n)) :=
+  dropR.symm.trans (τ'.trans (finSumFinEquiv.trans (finSuccEquiv' 0)))
+
+theorem restOptR_none {τ' : Equiv.Perm (Fin (m + 1) ⊕ Fin (n + 1))}
+    (hτ' : τ' (Sum.inr 0) = Sum.inl 0) : restOptR τ' none = none := by
+  have hz : finSumFinEquiv (Sum.inl (0 : Fin (m + 1)) : Fin (m + 1) ⊕ Fin (n + 1)) = 0 := by
+    apply Fin.ext; simp [finSumFinEquiv_apply_left]
+  rw [restOptR, Equiv.trans_apply, Equiv.trans_apply, Equiv.trans_apply, dropR_symm_none, hτ', hz]
+  exact finSuccEquiv'_at 0
+
+def restHatR (τ' : Equiv.Perm (Fin (m + 1) ⊕ Fin (n + 1))) :
+    Fin (m + 1) ⊕ Fin n ≃ Fin (m + 1 + n) :=
+  Equiv.removeNone (restOptR τ')
+
+def restPermR (τ' : Equiv.Perm (Fin (m + 1) ⊕ Fin (n + 1))) :
+    Equiv.Perm (Fin (m + 1) ⊕ Fin n) :=
+  (restHatR τ').trans finSumFinEquiv.symm
+
+theorem finSumFinEquiv_restPermR (τ' : Equiv.Perm (Fin (m + 1) ⊕ Fin (n + 1)))
+    (z : Fin (m + 1) ⊕ Fin n) : finSumFinEquiv (restPermR τ' z) = restHatR τ' z := by
+  simp [restPermR]
+
+theorem succ_restHatR (τ' : Equiv.Perm (Fin (m + 1) ⊕ Fin (n + 1)))
+    (hτ' : τ' (Sum.inr 0) = Sum.inl 0) (z : Fin (m + 1) ⊕ Fin n) :
+    (restHatR τ' z).succ = finSumFinEquiv (τ' (Sum.map id Fin.succ z)) := by
+  have hex : ∃ p, restOptR τ' (some z) = some p := by
+    rcases h : restOptR τ' (some z) with _ | p
+    · exact absurd ((restOptR τ').injective (h.trans (restOptR_none hτ').symm)) (by simp)
+    · exact ⟨p, rfl⟩
+  have hsome : some (restHatR τ' z) = restOptR τ' (some z) := Equiv.removeNone_some _ hex
+  have hz : dropR.symm (some z) = Sum.map id Fin.succ z := by rcases z with k | j <;> simp
+  rw [restOptR, Equiv.trans_apply, Equiv.trans_apply, Equiv.trans_apply, hz] at hsome
+  apply (finSuccEquiv' (0 : Fin (m + 1 + n + 1))).injective
+  rw [fse0_succ]
+  exact hsome
+
+theorem insPermR_restPermR (τ' : Equiv.Perm (Fin (m + 1) ⊕ Fin (n + 1)))
+    (hτ' : τ' (Sum.inr 0) = Sum.inl 0) : insPermR (restPermR τ') = τ' := by
+  ext z
+  rw [insPermR, Equiv.trans_apply, Equiv.symm_apply_eq]
+  rcases z with i | j
+  · rw [insHatR_inl, finSumFinEquiv_restPermR, succ_restHatR τ' hτ', Sum.map_inl, id]
+  · induction j using Fin.cases with
+    | zero =>
+      rw [insHatR_inr_zero, hτ']
+      apply Fin.ext; simp [finSumFinEquiv_apply_left]
+    | succ k =>
+      rw [insHatR_inr_succ, finSumFinEquiv_restPermR, succ_restHatR τ' hτ', Sum.map_inr]
+
+/- ---- Identity 2 (Part B) ---- -/
+theorem identityB (g : E [⋀^Fin (m + 1)]→L[𝕜] N) (h : E [⋀^Fin (n + 1)]→L[𝕜] N')
+    (f : N →L[𝕜] N' →L[𝕜] N'') (x₀ : E) (y : Fin (m + (n + 1)) → E) :
+    (-1 : 𝕜) ^ (m + 1) • ∑ b : Equiv.Perm.ModSumCongr (Fin (m + 1)) (Fin n),
+        uncurrySum.summand (f.compContinuousAlternatingMap₂ g (curryFin h x₀)) b
+          ((y ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv)
+      = ∑ σ ∈ Finset.univ.filter (fun q => ¬ isLeftClass q = true),
+        uncurrySum.summand (f.compContinuousAlternatingMap₂ g h) σ
+          ((Fin.cons x₀ y ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv) := by
+  rw [Finset.smul_sum]
+  refine Finset.sum_bij (fun b _ => projR b) ?_ ?_ ?_ ?_
+  · -- maps into right-classes
+    intro a _
+    rw [Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    induction a using Quotient.inductionOn' with
+    | _ b =>
+      have key : (insPermR b)⁻¹ (Sum.inl 0) = Sum.inr 0 := by
+        rw [Equiv.Perm.inv_eq_iff_eq]; exact (insPermR_inr_zero b).symm
+      simp only [projR_mk, isLeftClass, Quotient.liftOn'_mk'', key, Sum.isLeft_inr,
+        Bool.false_eq_true, not_false_eq_true]
+  · -- injective
+    intro a₁ _ a₂ _ heq
+    induction a₁ using Quotient.inductionOn' with
+    | _ b₁ =>
+    induction a₂ using Quotient.inductionOn' with
+    | _ b₂ =>
+      simp only [projR_mk] at heq
+      exact projR_left_injective b₁ b₂ heq
+  · -- surjective onto right-classes
+    intro c hc
+    rw [Finset.mem_filter] at hc
+    induction c using Quotient.inductionOn' with
+    | _ τ =>
+      rcases h0 : τ⁻¹ (Sum.inl 0) with i₀ | j₀
+      · exfalso
+        have hc2 := hc.2
+        simp only [isLeftClass, Quotient.liftOn'_mk'', h0, Sum.isLeft_inl, not_true_eq_false] at hc2
+      · set τ' := τ * Equiv.sumCongr (Equiv.refl (Fin (m + 1))) j₀.cycleRange.symm with hτ'def
+        have hτ' : τ' (Sum.inr 0) = Sum.inl 0 := by
+          rw [hτ'def, Equiv.Perm.mul_apply, Equiv.sumCongr_apply, Sum.map_inr,
+            Fin.cycleRange_symm_zero, ← h0, Equiv.Perm.apply_inv_self]
+        refine ⟨Quotient.mk'' (restPermR τ'), Finset.mem_univ _, ?_⟩
+        simp only [projR_mk]
+        rw [insPermR_restPermR τ' hτ', hτ'def, Quotient.eq'', QuotientGroup.leftRel_apply]
+        refine ⟨(Equiv.refl (Fin (m + 1)), j₀.cycleRange), ?_⟩
+        simp only [Equiv.Perm.sumCongrHom_apply]
+        have hg : (τ * Equiv.sumCongr (Equiv.refl (Fin (m + 1))) j₀.cycleRange.symm)⁻¹ * τ
+            = (Equiv.sumCongr (Equiv.refl (Fin (m + 1))) j₀.cycleRange.symm)⁻¹ := by group
+        rw [hg, Equiv.Perm.inv_def, Equiv.sumCongr_symm, Equiv.refl_symm, Equiv.symm_symm]
+  · -- term identity
+    intro a _
+    induction a using Quotient.inductionOn' with
+    | _ b => simp only [projR_mk]; exact (summandB g h f x₀ y b).symm
+
+/- ===================== Assembly: curryFin_wedge ===================== -/
+theorem curryFin_wedge (g : E [⋀^Fin (m + 1)]→L[𝕜] N) (h : E [⋀^Fin (n + 1)]→L[𝕜] N')
+    (f : N →L[𝕜] N' →L[𝕜] N'') (x₀ : E) :
+    curryFin (domDomCongr finAddFlipAssoc (wedge_product g h f)) x₀ =
+      wedge_product (curryFin g x₀) h f
+      + (-1 : 𝕜) ^ (m + 1) • domDomCongr finAddFlipAssoc (wedge_product g (curryFin h x₀) f) := by
+  ext y
+  rw [curryFin_apply, domDomCongr_apply, wedge_product_apply_sum]
+  show _ = (wedge_product (curryFin g x₀) h f) y
+      + ((-1 : 𝕜) ^ (m + 1) • domDomCongr finAddFlipAssoc (wedge_product g (curryFin h x₀) f)) y
+  rw [smul_apply, domDomCongr_apply, wedge_product_apply_sum, wedge_product_apply_sum,
+    identityA, identityB]
+  exact (Finset.sum_filter_add_sum_filter_not _ _ _).symm
+
 end commute
 
 end ContinuousAlternatingMap

--- a/DeRhamCohomology/ContinuousAlternatingMap/WedgeFDeriv.lean
+++ b/DeRhamCohomology/ContinuousAlternatingMap/WedgeFDeriv.lean
@@ -1,0 +1,816 @@
+import Mathlib.Analysis.Calculus.FDeriv.Mul
+import DeRhamCohomology.ContinuousAlternatingMap.Wedge
+import DeRhamCohomology.ContinuousAlternatingMap.FDeriv
+
+/-!
+# The wedge product as a bounded bilinear map and the Leibniz rule
+
+This file bundles `ContinuousAlternatingMap.wedge_product g h f` (with the bilinear pairing `f`
+fixed) as a continuous bilinear map `wedgeCLM f`, and uses it to differentiate
+`x ↦ wedge_product (ω x) (τ x) f`.
+
+It also proves the two algebraic "commutation" lemmas relating `uncurryFin` (the building block of
+the exterior derivative) to the wedge product, which are the combinatorial core of the graded
+Leibniz rule `ederiv_wedge`.
+-/
+
+noncomputable section
+suppress_compilation
+
+namespace ContinuousAlternatingMap
+
+open scoped BigOperators
+
+section bundle
+
+variable
+  {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {M : Type*} [NormedAddCommGroup M] [NormedSpace 𝕜 M]
+  {N : Type*} [NormedAddCommGroup N] [NormedSpace 𝕜 N]
+  {N' : Type*} [NormedAddCommGroup N'] [NormedSpace 𝕜 N']
+  {N'' : Type*} [NormedAddCommGroup N''] [NormedSpace 𝕜 N'']
+  {m n : ℕ}
+
+/-- The wedge product is linear in its left argument. -/
+theorem smul_wedge_left (g : M [⋀^Fin m]→L[𝕜] N) (h : M [⋀^Fin n]→L[𝕜] N')
+    (f : N →L[𝕜] N' →L[𝕜] N'') (c : 𝕜) :
+    (wedge_product (c • g) h f) = c • (wedge_product g h f) := by
+  ext x
+  rw [smul_apply, wedge_product_def, uncurryFinAdd, domDomCongr_apply, uncurrySum_apply,
+    wedge_product_def, uncurryFinAdd, domDomCongr_apply, uncurrySum_apply,
+    ContinuousMultilinearMap.sum_apply, ContinuousMultilinearMap.sum_apply, Finset.smul_sum]
+  apply Finset.sum_congr rfl
+  intro σ hσ
+  rcases σ with ⟨σ₁⟩
+  rw [uncurrySum.summand_mk, uncurrySum.summand_mk]
+  simp only [ContinuousMultilinearMap.smul_apply, ContinuousMultilinearMap.domDomCongr_apply,
+    Function.comp_apply, ContinuousMultilinearMap.uncurrySum_apply,
+    ContinuousMultilinearMap.flipMultilinear_apply, coe_toContinuousMultilinearMap,
+    ContinuousMultilinearMap.flipAlternating_apply,
+    ContinuousLinearMap.compContinuousAlternatingMap₂_apply, smul_apply, map_smul,
+    ContinuousLinearMap.smul_apply]
+  rw [smul_comm]
+
+/-- The wedge product is linear in its right argument. -/
+theorem smul_wedge_right (g : M [⋀^Fin m]→L[𝕜] N) (h : M [⋀^Fin n]→L[𝕜] N')
+    (f : N →L[𝕜] N' →L[𝕜] N'') (c : 𝕜) :
+    (wedge_product g (c • h) f) = c • (wedge_product g h f) := by
+  ext x
+  rw [smul_apply, wedge_product_def, uncurryFinAdd, domDomCongr_apply, uncurrySum_apply,
+    wedge_product_def, uncurryFinAdd, domDomCongr_apply, uncurrySum_apply,
+    ContinuousMultilinearMap.sum_apply, ContinuousMultilinearMap.sum_apply, Finset.smul_sum]
+  apply Finset.sum_congr rfl
+  intro σ hσ
+  rcases σ with ⟨σ₁⟩
+  rw [uncurrySum.summand_mk, uncurrySum.summand_mk]
+  simp only [ContinuousMultilinearMap.smul_apply, ContinuousMultilinearMap.domDomCongr_apply,
+    Function.comp_apply, ContinuousMultilinearMap.uncurrySum_apply,
+    ContinuousMultilinearMap.flipMultilinear_apply, coe_toContinuousMultilinearMap,
+    ContinuousMultilinearMap.flipAlternating_apply,
+    ContinuousLinearMap.compContinuousAlternatingMap₂_apply, smul_apply, map_smul,
+    ContinuousLinearMap.smul_apply]
+  rw [smul_comm]
+
+/-- Norm bound on a single summand of the (shuffle expansion of the) wedge product. -/
+theorem norm_summand_compContinuousAlternatingMap₂_le
+    (f : N →L[𝕜] N' →L[𝕜] N'') (g : M [⋀^Fin m]→L[𝕜] N) (h : M [⋀^Fin n]→L[𝕜] N')
+    (σ : Equiv.Perm.ModSumCongr (Fin m) (Fin n)) (z : Fin (m + n) → M) :
+    ‖uncurrySum.summand (f.compContinuousAlternatingMap₂ g h) σ (z ∘ finSumFinEquiv)‖
+      ≤ ‖f‖ * ‖g‖ * ‖h‖ * ∏ k, ‖z k‖ := by
+  induction σ using Quotient.inductionOn' with
+  | _ σ₁ =>
+    rw [uncurrySum.summand_mk'']
+    simp only [ContinuousMultilinearMap.smul_apply, ContinuousMultilinearMap.domDomCongr_apply,
+      Function.comp_apply, ContinuousMultilinearMap.uncurrySum_apply,
+      ContinuousMultilinearMap.flipMultilinear_apply, coe_toContinuousMultilinearMap,
+      ContinuousMultilinearMap.flipAlternating_apply,
+      ContinuousLinearMap.compContinuousAlternatingMap₂_apply, norm_units_zsmul]
+    refine (f.le_opNorm₂ _ _).trans ?_
+    calc ‖f‖ * ‖g (fun i => z (finSumFinEquiv (σ₁ (Sum.inl i))))‖
+            * ‖h (fun j => z (finSumFinEquiv (σ₁ (Sum.inr j))))‖
+        ≤ ‖f‖ * (‖g‖ * ∏ i, ‖z (finSumFinEquiv (σ₁ (Sum.inl i)))‖)
+            * (‖h‖ * ∏ j, ‖z (finSumFinEquiv (σ₁ (Sum.inr j)))‖) := by
+          gcongr <;> [exact g.le_opNorm _; exact h.le_opNorm _]
+      _ = ‖f‖ * ‖g‖ * ‖h‖
+            * ((∏ i, ‖z (finSumFinEquiv (σ₁ (Sum.inl i)))‖)
+              * ∏ j, ‖z (finSumFinEquiv (σ₁ (Sum.inr j)))‖) := by ring
+      _ = ‖f‖ * ‖g‖ * ‖h‖ * ∏ k, ‖z k‖ := by
+          congr 1
+          rw [← Fintype.prod_sum_type fun s => ‖z (finSumFinEquiv (σ₁ s))‖,
+              Equiv.prod_comp σ₁ fun s => ‖z (finSumFinEquiv s)‖,
+              Equiv.prod_comp finSumFinEquiv fun k => ‖z k‖]
+
+/-- The operator-norm bound on the wedge product, used to bundle it as a continuous bilinear map. -/
+theorem norm_wedge_le (f : N →L[𝕜] N' →L[𝕜] N'') (g : M [⋀^Fin m]→L[𝕜] N)
+    (h : M [⋀^Fin n]→L[𝕜] N') :
+    ‖wedge_product g h f‖
+      ≤ (Fintype.card (Equiv.Perm.ModSumCongr (Fin m) (Fin n)) : ℝ) * ‖f‖ * ‖g‖ * ‖h‖ := by
+  refine opNorm_le_bound _ (by positivity) fun z => ?_
+  rw [wedge_product_def, uncurryFinAdd, domDomCongr_apply, uncurrySum_apply,
+    ContinuousMultilinearMap.sum_apply]
+  refine (norm_sum_le _ _).trans ?_
+  calc ∑ σ : Equiv.Perm.ModSumCongr (Fin m) (Fin n),
+          ‖uncurrySum.summand (f.compContinuousAlternatingMap₂ g h) σ (z ∘ finSumFinEquiv)‖
+      ≤ ∑ _σ : Equiv.Perm.ModSumCongr (Fin m) (Fin n), ‖f‖ * ‖g‖ * ‖h‖ * ∏ k, ‖z k‖ :=
+        Finset.sum_le_sum fun σ _ =>
+          norm_summand_compContinuousAlternatingMap₂_le f g h σ z
+    _ = (Fintype.card (Equiv.Perm.ModSumCongr (Fin m) (Fin n)) : ℝ) * ‖f‖ * ‖g‖ * ‖h‖
+          * ∏ k, ‖z k‖ := by
+        rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]
+        ring
+
+/-- The wedge product with respect to a fixed pairing `f`, bundled as a continuous bilinear map. -/
+def wedgeCLM (f : N →L[𝕜] N' →L[𝕜] N'') :
+    (M [⋀^Fin m]→L[𝕜] N) →L[𝕜] (M [⋀^Fin n]→L[𝕜] N') →L[𝕜] (M [⋀^Fin (m + n)]→L[𝕜] N'') :=
+  LinearMap.mkContinuous₂
+    (LinearMap.mk₂ 𝕜 (fun g h => wedge_product g h f)
+      (fun g₁ g₂ h => add_wedge g₁ g₂ h f)
+      (fun c g h => smul_wedge_left g h f c)
+      (fun g h₁ h₂ => wedge_add g h₁ h₂ f)
+      (fun c g h => smul_wedge_right g h f c))
+    (Fintype.card (Equiv.Perm.ModSumCongr (Fin m) (Fin n)) * ‖f‖)
+    fun g h => by
+      rw [mul_assoc, mul_assoc]
+      simpa only [mul_assoc] using norm_wedge_le f g h
+
+@[simp]
+theorem wedgeCLM_apply (f : N →L[𝕜] N' →L[𝕜] N'') (g : M [⋀^Fin m]→L[𝕜] N)
+    (h : M [⋀^Fin n]→L[𝕜] N') :
+    ((wedgeCLM f : (M [⋀^Fin m]→L[𝕜] N) →L[𝕜] (M [⋀^Fin n]→L[𝕜] N') →L[𝕜]
+      M [⋀^Fin (m + n)]→L[𝕜] N'') g) h = wedge_product g h f :=
+  rfl
+
+end bundle
+
+section fderiv
+
+variable
+  {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {M : Type*} [NormedAddCommGroup M] [NormedSpace 𝕜 M]
+  {N : Type*} [NormedAddCommGroup N] [NormedSpace 𝕜 N]
+  {N' : Type*} [NormedAddCommGroup N'] [NormedSpace 𝕜 N']
+  {N'' : Type*} [NormedAddCommGroup N''] [NormedSpace 𝕜 N'']
+  {m n : ℕ}
+
+/-- The Leibniz rule for the Fréchet derivative of a wedge product of (alternating-map valued)
+functions: differentiating `x ↦ wedge_product (ω x) (τ x) f` follows the product rule of the
+bounded bilinear map `wedgeCLM f`. The two summands are written via `precompR`/`precompL`, which
+postcompose the bilinear map with the derivatives.
+
+We go through `ContinuousLinearMap.fderiv_of_bilinear`, which differentiates the
+`ContinuousAlternatingMap`-valued map `p ↦ wedgeCLM f p.1 p.2`; this avoids the normed-instance
+diamond that arises when differentiating a `ContinuousLinearMap`-valued (curried) function. -/
+theorem fderiv_wedge (f : N →L[𝕜] N' →L[𝕜] N'')
+    {ω : E → M [⋀^Fin m]→L[𝕜] N} {τ : E → M [⋀^Fin n]→L[𝕜] N'} {x : E}
+    (hω : DifferentiableAt 𝕜 ω x) (hτ : DifferentiableAt 𝕜 τ x) :
+    fderiv 𝕜 (fun y => wedge_product (ω y) (τ y) f) x =
+      (wedgeCLM (M := M) (m := m) (n := n) f).precompR E (ω x) (fderiv 𝕜 τ x)
+        + (wedgeCLM (M := M) (m := m) (n := n) f).precompL E (fderiv 𝕜 ω x) (τ x) := by
+  have h := (wedgeCLM (M := M) (m := m) (n := n) f).fderiv_of_bilinear
+    (f := ω) (g := τ) hω hτ
+  simpa only [wedgeCLM_apply] using h
+
+end fderiv
+
+section commute
+
+variable
+  {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {N : Type*} [NormedAddCommGroup N] [NormedSpace 𝕜 N]
+  {N' : Type*} [NormedAddCommGroup N'] [NormedSpace 𝕜 N']
+  {N'' : Type*} [NormedAddCommGroup N''] [NormedSpace 𝕜 N'']
+  {G : Type*} [NormedAddCommGroup G] [NormedSpace 𝕜 G]
+  {m n : ℕ}
+
+/-- `uncurryFin` (prepending a derivative slot) commutes with post-composition by a fixed
+continuous linear map `L`. This is the quotient-free part of the wedge/uncurry interaction. -/
+theorem uncurryFin_compContinuousAlternatingMapCLM (L : N →L[𝕜] G)
+    (A : E →L[𝕜] (E [⋀^Fin m]→L[𝕜] N)) :
+    uncurryFin ((ContinuousLinearMap.compContinuousAlternatingMapCLM 𝕜 E N G L).comp A) =
+      L.compContinuousAlternatingMap (uncurryFin A) := by
+  ext w
+  simp only [uncurryFin_apply, ContinuousLinearMap.compContinuousAlternatingMap_coe,
+    Function.comp_apply, ContinuousLinearMap.comp_apply,
+    ContinuousLinearMap.compContinuousAlternatingMapCLM_apply_apply]
+  exact ((_root_.map_sum L _ _).trans
+    (Finset.sum_congr rfl fun k _ => _root_.map_zsmul L _ _)).symm
+
+/-- The wedge product, evaluated, as the shuffle sum over `ModSumCongr`. -/
+theorem wedge_product_apply_sum (g : E [⋀^Fin m]→L[𝕜] N) (h : E [⋀^Fin n]→L[𝕜] N')
+    (f : N →L[𝕜] N' →L[𝕜] N'') (w : Fin (m + n) → E) :
+    wedge_product g h f w = ∑ σ : Equiv.Perm.ModSumCongr (Fin m) (Fin n),
+      uncurrySum.summand (f.compContinuousAlternatingMap₂ g h) σ (w ∘ finSumFinEquiv) := by
+  rw [wedge_product_def, uncurryFinAdd, domDomCongr_apply, uncurrySum_apply,
+    ContinuousMultilinearMap.sum_apply]
+
+/-- `compContinuousAlternatingMap₂ f g h` is post-composition of `g` by the fixed continuous
+linear map `((compContinuousAlternatingMapCLM 𝕜 E N' N'').flip h).comp f`. This is definitional,
+and it lets us feed `compContinuousAlternatingMap₂` to
+`uncurryFin_compContinuousAlternatingMapCLM`. -/
+theorem compContinuousAlternatingMap₂_eq_comp (f : N →L[𝕜] N' →L[𝕜] N'')
+    (g : E [⋀^Fin m]→L[𝕜] N) (h : E [⋀^Fin n]→L[𝕜] N') :
+    f.compContinuousAlternatingMap₂ g h =
+      (((ContinuousLinearMap.compContinuousAlternatingMapCLM 𝕜 E N' N'').flip h).comp
+        f).compContinuousAlternatingMap g :=
+  rfl
+
+/-- Evaluation of a single `uncurrySum.summand` at a representative permutation `a₁`. -/
+theorem summand_mk_eval
+    {ι ι' : Type*} [Fintype ι] [Fintype ι'] [DecidableEq ι] [DecidableEq ι']
+    (F : E [⋀^ι]→L[𝕜] (E [⋀^ι']→L[𝕜] G)) (a₁ : Equiv.Perm (ι ⊕ ι'))
+    (w : ι ⊕ ι' → E) :
+    uncurrySum.summand F (Quotient.mk'' a₁) w
+      = Equiv.Perm.sign a₁ • F (fun i => w (a₁ (Sum.inl i))) (fun j => w (a₁ (Sum.inr j))) := by
+  rw [uncurrySum.summand_mk'']
+  simp only [ContinuousMultilinearMap.smul_apply, ContinuousMultilinearMap.domDomCongr_apply,
+    Function.comp_apply, ContinuousMultilinearMap.uncurrySum_apply,
+    ContinuousMultilinearMap.flipMultilinear_apply, coe_toContinuousMultilinearMap,
+    ContinuousMultilinearMap.flipAlternating_apply]
+  rfl
+
+/-- The value-preserving relabelling `Fin (m+1) ⊕ Fin n ≃ Fin (m+n+1)`, used to lay out the
+arguments of the right-hand side. -/
+def insSumEquiv : Fin (m + 1) ⊕ Fin n ≃ Fin (m + n + 1) :=
+  finSumFinEquiv.trans finAddFlipAssoc
+
+/-- The equivalence `Option (Fin m) ⊕ Fin n ≃ Option (Fin m ⊕ Fin n)`:
+`inl none ↦ none`, `inl (some k) ↦ some (inl k)`, `inr j ↦ some (inr j)`. -/
+def optSumL : Option (Fin m) ⊕ Fin n ≃ Option (Fin m ⊕ Fin n) where
+  toFun := Sum.elim (fun o => o.map Sum.inl) (fun j => some (Sum.inr j))
+  invFun := fun o => o.elim (Sum.inl none) (Sum.elim (fun k => Sum.inl (some k)) Sum.inr)
+  left_inv := by rintro ((_ | _) | _) <;> rfl
+  right_inv := by rintro (_ | (_ | _)) <;> rfl
+
+@[simp] theorem optSumL_inl_none : (optSumL (m := m) (n := n)) (Sum.inl none) = none := rfl
+@[simp] theorem optSumL_inl_some (k : Fin m) :
+    (optSumL (n := n)) (Sum.inl (some k)) = some (Sum.inl k) := rfl
+@[simp] theorem optSumL_inr (j : Fin n) :
+    (optSumL (m := m)) (Sum.inr j) = some (Sum.inr j) := rfl
+
+/-- Drop the slot `i` from the left block: `Fin (m+1) ⊕ Fin n ≃ Option (Fin m ⊕ Fin n)`.
+`inl i ↦ none`, `inl (i.succAbove k) ↦ some (inl k)`, `inr j ↦ some (inr j)`. -/
+def dropL (i : Fin (m + 1)) : Fin (m + 1) ⊕ Fin n ≃ Option (Fin m ⊕ Fin n) :=
+  (Equiv.sumCongr (finSuccEquiv' i) (Equiv.refl (Fin n))).trans optSumL
+
+@[simp] theorem dropL_self (i : Fin (m + 1)) : (dropL (n := n) i) (Sum.inl i) = none := by
+  simp [dropL]
+@[simp] theorem dropL_succAbove (i : Fin (m + 1)) (k : Fin m) :
+    (dropL (n := n) i) (Sum.inl (i.succAbove k)) = some (Sum.inl k) := by
+  simp [dropL]
+@[simp] theorem dropL_inr (i : Fin (m + 1)) (j : Fin n) :
+    (dropL (m := m) i) (Sum.inr j) = some (Sum.inr j) := by
+  simp [dropL]
+
+@[simp] theorem optSumL_symm_none : (optSumL (m := m) (n := n)).symm none = Sum.inl none := rfl
+@[simp] theorem optSumL_symm_some_inl (k : Fin m) :
+    (optSumL (n := n)).symm (some (Sum.inl k)) = Sum.inl (some k) := rfl
+@[simp] theorem optSumL_symm_some_inr (j : Fin n) :
+    (optSumL (m := m)).symm (some (Sum.inr j)) = Sum.inr j := rfl
+
+@[simp] theorem dropL_symm_none (i : Fin (m + 1)) :
+    (dropL (n := n) i).symm none = Sum.inl i := by simp [dropL]
+@[simp] theorem dropL_symm_some_inl (i : Fin (m + 1)) (k : Fin m) :
+    (dropL (n := n) i).symm (some (Sum.inl k)) = Sum.inl (i.succAbove k) := by simp [dropL]
+@[simp] theorem dropL_symm_some_inr (i : Fin (m + 1)) (j : Fin n) :
+    (dropL (m := m) i).symm (some (Sum.inr j)) = Sum.inr j := by simp [dropL]
+
+variable (G) in
+/-- Given a target output position `x : Fin (m+n+1)` and a shuffle `σ : Perm (Fin m ⊕ Fin n)`,
+the equivalence `Fin (m+1) ⊕ Fin n ≃ Fin (m+n+1)` that places the new (marked) left slot `inl 0`
+at output position `x`, and lays out the remaining `m+n` slots through `σ` into the complement of
+`x` (enumerated by `x.succAbove`). -/
+def insHat (x : Fin (m + n + 1)) (σ : Equiv.Perm (Fin m ⊕ Fin n)) :
+    Fin (m + 1) ⊕ Fin n ≃ Fin (m + n + 1) :=
+  (dropL 0).trans <| (Equiv.optionCongr σ).trans <|
+    (Equiv.optionCongr finSumFinEquiv).trans (finSuccEquiv' x).symm
+
+theorem insHat_inl_zero (x : Fin (m + n + 1)) (σ : Equiv.Perm (Fin m ⊕ Fin n)) :
+    insHat x σ (Sum.inl 0) = x := by
+  simp [insHat]
+
+theorem insHat_inl_succ (x : Fin (m + n + 1)) (σ : Equiv.Perm (Fin m ⊕ Fin n)) (k : Fin m) :
+    insHat x σ (Sum.inl k.succ) = x.succAbove (finSumFinEquiv (σ (Sum.inl k))) := by
+  have hk : (Sum.inl k.succ : Fin (m + 1) ⊕ Fin n) = Sum.inl ((0 : Fin (m + 1)).succAbove k) := by
+    rw [Fin.succAbove_zero]
+  simp only [insHat, Equiv.trans_apply, hk, dropL_succAbove, Equiv.optionCongr_apply,
+    Option.map_some, Function.comp_apply, finSuccEquiv'_symm_some]
+
+theorem insHat_inr (x : Fin (m + n + 1)) (σ : Equiv.Perm (Fin m ⊕ Fin n)) (j : Fin n) :
+    insHat x σ (Sum.inr j) = x.succAbove (finSumFinEquiv (σ (Sum.inr j))) := by
+  simp [insHat]
+
+theorem coe_insSumEquiv (z : Fin (m + 1) ⊕ Fin n) :
+    (insSumEquiv z : ℕ) = (finSumFinEquiv z : ℕ) := by
+  simp only [insSumEquiv, Equiv.trans_apply, finAddFlipAssoc, finCongr_apply_coe]
+
+@[simp] theorem insSumEquiv_inl_zero : insSumEquiv (Sum.inl (0 : Fin (m + 1)) : Fin (m + 1) ⊕ Fin n)
+    = 0 := by
+  apply Fin.ext
+  rw [coe_insSumEquiv]
+  simp
+
+theorem insSumEquiv_inl_succ (k : Fin m) :
+    insSumEquiv (Sum.inl k.succ : Fin (m + 1) ⊕ Fin n)
+      = (finSumFinEquiv (Sum.inl k) : Fin (m + n)).succ := by
+  apply Fin.ext
+  rw [coe_insSumEquiv]
+  simp [Fin.val_succ]
+
+theorem insSumEquiv_inr_eq_succ (j : Fin n) :
+    insSumEquiv (Sum.inr j : Fin (m + 1) ⊕ Fin n)
+      = (finSumFinEquiv (Sum.inr j) : Fin (m + n)).succ := by
+  apply Fin.ext
+  rw [coe_insSumEquiv]
+  simp only [finSumFinEquiv_apply_right, Fin.coe_natAdd, Fin.val_succ]
+  omega
+
+/-- The permutation of `Fin (m+1) ⊕ Fin n` obtained from `insHat x σ` by reading the output
+through `insSumEquiv`. Inserting the marked slot at `inl 0` mapping to output `x`. -/
+def insPerm (x : Fin (m + n + 1)) (σ : Equiv.Perm (Fin m ⊕ Fin n)) :
+    Equiv.Perm (Fin (m + 1) ⊕ Fin n) :=
+  (insHat x σ).trans insSumEquiv.symm
+
+/-- Inserting a fixed marked slot at output `0` does not change the sign. -/
+theorem sign_insPerm_zero (σ : Equiv.Perm (Fin m ⊕ Fin n)) :
+    Equiv.Perm.sign (insPerm 0 σ) = Equiv.Perm.sign σ := by
+  have key : insHat 0 σ
+      = insSumEquiv.trans (Equiv.Perm.decomposeFin.symm (0, finSumFinEquiv.permCongr σ)) := by
+    ext z
+    rw [Equiv.trans_apply]
+    rcases z with i | j
+    · induction i using Fin.cases with
+      | zero =>
+        rw [insHat_inl_zero, insSumEquiv_inl_zero, Equiv.Perm.decomposeFin_symm_apply_zero]
+      | succ k =>
+        rw [insHat_inl_succ, insSumEquiv_inl_succ, Equiv.Perm.decomposeFin_symm_apply_succ,
+          Equiv.swap_self, Equiv.refl_apply, Fin.succAbove_zero, Equiv.permCongr_apply,
+          Equiv.symm_apply_apply]
+    · rw [insHat_inr, insSumEquiv_inr_eq_succ, Equiv.Perm.decomposeFin_symm_apply_succ,
+        Equiv.swap_self, Equiv.refl_apply, Fin.succAbove_zero, Equiv.permCongr_apply,
+        Equiv.symm_apply_apply]
+  rw [insPerm, key, Equiv.Perm.sign_trans_trans_symm, Equiv.Perm.decomposeFin.symm_sign,
+    if_pos rfl, one_mul, Equiv.Perm.sign_permCongr]
+
+/-- `insHat x σ` is `insHat 0 σ` followed by the cycle moving the output `0` to `x`. -/
+theorem insHat_eq_trans_cycleRange (x : Fin (m + n + 1)) (σ : Equiv.Perm (Fin m ⊕ Fin n)) :
+    insHat x σ = (insHat 0 σ).trans x.cycleRange.symm := by
+  have hsymm : (finSuccEquiv' x).symm
+      = ((finSuccEquiv' (0 : Fin (m + n + 1))).symm).trans x.cycleRange.symm := by
+    ext o
+    rcases o with _ | p
+    · simp [Fin.succAbove_zero]
+    · simp [Fin.succAbove_zero, Fin.cycleRange_symm_succ]
+  ext z
+  simp only [insHat, Equiv.trans_apply, hsymm]
+
+/-- The sign of the inserting permutation: inserting the marked slot at output position `x`
+contributes the cyclic sign `(-1)^x`. -/
+theorem sign_insPerm (x : Fin (m + n + 1)) (σ : Equiv.Perm (Fin m ⊕ Fin n)) :
+    Equiv.Perm.sign (insPerm x σ) = (-1) ^ (x : ℕ) * Equiv.Perm.sign σ := by
+  have hperm : insSumEquiv.permCongr (insPerm x σ)
+      = x.cycleRange.symm * insSumEquiv.permCongr (insPerm 0 σ) := by
+    ext y
+    simp only [Equiv.permCongr_apply, insPerm, insHat_eq_trans_cycleRange x σ,
+      Equiv.symm_trans_apply, Equiv.symm_symm, Equiv.trans_apply, Equiv.apply_symm_apply,
+      Equiv.Perm.mul_apply, Equiv.apply_symm_apply]
+  rw [← Equiv.Perm.sign_permCongr insSumEquiv (insPerm x σ), hperm, map_mul,
+    Equiv.Perm.sign_symm, Fin.sign_cycleRange, Equiv.Perm.sign_permCongr, sign_insPerm_zero]
+
+/-- The within-left-block permutation moving slot `0` to slot `i`. Lies in the range of
+`sumCongrHom`, hence preserves the `ModSumCongr` class on right multiplication. -/
+def slotMove (i : Fin (m + 1)) : Equiv.Perm (Fin (m + 1) ⊕ Fin n) :=
+  Equiv.sumCongr i.cycleRange.symm (Equiv.refl (Fin n))
+
+/-- The output position of the marked left slot `inl i` of a representative `τ`. -/
+def markedOut (τ : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (i : Fin (m + 1)) : Fin (m + n + 1) :=
+  insSumEquiv (τ (Sum.inl i))
+
+/-- The `Option`-encoded equivalence used to extract the "rest" shuffle from `τ` after marking
+slot `i`. It fixes `none`. -/
+def restOpt (τ : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (i : Fin (m + 1)) :
+    Option (Fin m ⊕ Fin n) ≃ Option (Fin (m + n)) :=
+  (dropL i).symm.trans (τ.trans (insSumEquiv.trans (finSuccEquiv' (markedOut τ i))))
+
+theorem restOpt_none (τ : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (i : Fin (m + 1)) :
+    restOpt τ i none = none := by
+  simp only [restOpt, Equiv.trans_apply, dropL_symm_none, markedOut, finSuccEquiv'_at]
+
+/-- The "rest" shuffle as an equivalence `Fin m ⊕ Fin n ≃ Fin (m+n)`. -/
+def restHat (τ : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (i : Fin (m + 1)) :
+    Fin m ⊕ Fin n ≃ Fin (m + n) :=
+  Equiv.removeNone (restOpt τ i)
+
+/-- The "rest" shuffle as a permutation of `Fin m ⊕ Fin n`. -/
+def restPerm (τ : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (i : Fin (m + 1)) :
+    Equiv.Perm (Fin m ⊕ Fin n) :=
+  (restHat τ i).trans finSumFinEquiv.symm
+
+/-- The key matching identity: laying out the marked layout of `τ` through `insSumEquiv`
+recovers the `restHat` shuffle, shifted past the marked output `markedOut τ i`. -/
+theorem succAbove_restHat (τ : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (i : Fin (m + 1))
+    (z : Fin m ⊕ Fin n) :
+    (markedOut τ i).succAbove (restHat τ i z)
+      = insSumEquiv (τ (Sum.map i.succAbove id z)) := by
+  have hex : ∃ p, restOpt τ i (some z) = some p := by
+    rcases h : restOpt τ i (some z) with _ | p
+    · exact absurd (((restOpt τ i).injective (h.trans (restOpt_none τ i).symm))) (by simp)
+    · exact ⟨p, rfl⟩
+  have hsome : some (restHat τ i z) = restOpt τ i (some z) := Equiv.removeNone_some _ hex
+  have hz : (dropL i).symm (some z) = Sum.map i.succAbove id z := by
+    rcases z with k | j <;> simp
+  simp only [restHat, restOpt, Equiv.trans_apply, hz] at hsome
+  have := congrArg (finSuccEquiv' (markedOut τ i)).symm hsome
+  rwa [finSuccEquiv'_symm_some, Equiv.symm_apply_apply] at this
+
+@[simp] theorem slotMove_inl_zero (i : Fin (m + 1)) :
+    (slotMove (n := n) i) (Sum.inl 0) = Sum.inl i := by simp [slotMove]
+@[simp] theorem slotMove_inl_succ (i : Fin (m + 1)) (k : Fin m) :
+    (slotMove (n := n) i) (Sum.inl k.succ) = Sum.inl (i.succAbove k) := by
+  simp [slotMove, Fin.cycleRange_symm_succ]
+@[simp] theorem slotMove_inr (i : Fin (m + 1)) (j : Fin n) :
+    (slotMove (m := m) i) (Sum.inr j) = Sum.inr j := by simp [slotMove]
+
+theorem finSumFinEquiv_restPerm (τ : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (i : Fin (m + 1))
+    (z : Fin m ⊕ Fin n) : finSumFinEquiv (restPerm τ i z) = restHat τ i z := by
+  simp [restPerm]
+
+/-- The inserting permutation built from `(markedOut τ i, restPerm τ i)` is exactly `τ` with the
+marked left slot moved back from `0` to `i`. -/
+theorem insPerm_markedOut_restPerm (τ : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (i : Fin (m + 1)) :
+    insPerm (markedOut τ i) (restPerm τ i) = τ * slotMove i := by
+  ext z
+  rw [insPerm, Equiv.trans_apply, Equiv.Perm.mul_apply]
+  rcases z with I | j
+  · induction I using Fin.cases with
+    | zero =>
+      rw [insHat_inl_zero, slotMove_inl_zero, markedOut, Equiv.symm_apply_apply]
+    | succ k =>
+      rw [insHat_inl_succ, slotMove_inl_succ, finSumFinEquiv_restPerm, succAbove_restHat]
+      simp only [Sum.map_inl, id, Equiv.symm_apply_apply]
+  · rw [insHat_inr, slotMove_inr, finSumFinEquiv_restPerm, succAbove_restHat (z := Sum.inr j)]
+    simp only [Sum.map_inr, id, Equiv.symm_apply_apply]
+
+@[simp] theorem sign_slotMove (i : Fin (m + 1)) :
+    Equiv.Perm.sign (slotMove (n := n) i) = (-1) ^ (i : ℕ) := by
+  rw [slotMove, Equiv.Perm.sign_sumCongr, Equiv.Perm.sign_symm, Fin.sign_cycleRange,
+    Equiv.Perm.sign_refl, mul_one]
+
+theorem slotMove_inv (i : Fin (m + 1)) :
+    (slotMove (n := n) i)⁻¹ = Equiv.sumCongr i.cycleRange (Equiv.refl (Fin n)) := by
+  rw [Equiv.Perm.inv_def, slotMove, Equiv.sumCongr_symm, Equiv.refl_symm, Equiv.symm_symm]
+
+/-- The representative-level sign identity at the heart of the shuffle/Pascal recursion. -/
+theorem sign_restPerm (τ : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) (i : Fin (m + 1)) :
+    (-1) ^ (markedOut τ i : ℕ) * Equiv.Perm.sign (restPerm τ i)
+      = Equiv.Perm.sign τ * (-1) ^ (i : ℕ) := by
+  have h := insPerm_markedOut_restPerm τ i
+  apply_fun Equiv.Perm.sign at h
+  rwa [sign_insPerm, map_mul, sign_slotMove] at h
+
+/-- Descent: `insPerm x` carries within-block reshuffles of `σ` to within-block reshuffles of
+`insPerm x σ`, hence descends to the `ModSumCongr` quotient. -/
+theorem insPerm_mul_sumCongr (x : Fin (m + n + 1)) (σ : Equiv.Perm (Fin m ⊕ Fin n))
+    (sl : Equiv.Perm (Fin m)) (sr : Equiv.Perm (Fin n)) :
+    insPerm x (σ * Equiv.sumCongr sl sr)
+      = insPerm x σ * Equiv.sumCongr (Equiv.Perm.decomposeFin.symm (0, sl)) sr := by
+  ext z
+  rw [Equiv.Perm.mul_apply, insPerm, Equiv.trans_apply, insPerm, Equiv.trans_apply]
+  congr 1
+  rcases z with I | j
+  · induction I using Fin.cases with
+    | zero =>
+      rw [Equiv.sumCongr_apply, Sum.map_inl, Equiv.Perm.decomposeFin_symm_apply_zero,
+        insHat_inl_zero, insHat_inl_zero]
+    | succ k =>
+      rw [Equiv.sumCongr_apply, Sum.map_inl, Equiv.Perm.decomposeFin_symm_apply_succ,
+        Equiv.swap_self, Equiv.refl_apply, insHat_inl_succ, insHat_inl_succ,
+        Equiv.Perm.mul_apply, Equiv.sumCongr_apply, Sum.map_inl]
+  · simp only [Equiv.sumCongr_apply, Sum.map_inr, id_eq, insHat_inr, Equiv.Perm.mul_apply]
+
+open Equiv.Perm in
+theorem proj_spec (x : Fin (m + n + 1)) (a b : Equiv.Perm (Fin m ⊕ Fin n))
+    (h : (QuotientGroup.leftRel (Equiv.Perm.sumCongrHom (Fin m) (Fin n)).range) a b) :
+    (Quot.mk (⇑(QuotientGroup.leftRel (sumCongrHom (Fin (m + 1)) (Fin n)).range))
+        (insPerm x a)) =
+      (Quot.mk (⇑(QuotientGroup.leftRel (sumCongrHom (Fin (m + 1)) (Fin n)).range))
+        (insPerm x b)) := by
+  apply Quot.sound
+  rw [QuotientGroup.leftRel_apply] at h ⊢
+  obtain ⟨⟨sl, sr⟩, hb⟩ := h
+  simp only [sumCongrHom_apply, MonoidHom.coe_mk, OneHom.coe_mk] at hb
+  have hbb : b = a * Equiv.sumCongr sl sr := by
+    rw [show Equiv.sumCongr sl sr = sl.sumCongr sr from rfl, hb, mul_inv_cancel_left]
+  rw [hbb, insPerm_mul_sumCongr]
+  refine ⟨(Equiv.Perm.decomposeFin.symm (0, sl), sr), ?_⟩
+  simp only [sumCongrHom_apply]
+  group
+
+/-- The fibrewise projection sending a marked output position `x` together with a shuffle class of
+`Fin m ⊕ Fin n` to the shuffle class of `Fin (m+1) ⊕ Fin n` obtained by inserting the marked slot
+at `inl 0`. -/
+def proj (p : Fin (m + n + 1) × Equiv.Perm.ModSumCongr (Fin m) (Fin n)) :
+    Equiv.Perm.ModSumCongr (Fin (m + 1)) (Fin n) :=
+  Quotient.liftOn' p.2 (fun σ => Quotient.mk'' (insPerm p.1 σ)) (proj_spec p.1)
+
+@[simp] theorem proj_mk (x : Fin (m + n + 1)) (σ : Equiv.Perm (Fin m ⊕ Fin n)) :
+    proj (x, Quotient.mk'' σ) = Quotient.mk'' (insPerm x σ) := rfl
+
+theorem insHat_injective (x : Fin (m + n + 1)) (σ : Equiv.Perm (Fin m ⊕ Fin n)) :
+    Function.Injective (insHat x σ) := (insHat x σ).injective
+
+/-- `insPerm x` is injective in its shuffle argument. -/
+theorem insPerm_left_injective (x : Fin (m + n + 1)) :
+    Function.Injective (insPerm x : Equiv.Perm (Fin m ⊕ Fin n) → _) := by
+  intro σ₁ σ₂ h
+  have h' : insHat x σ₁ = insHat x σ₂ := by
+    have := congrArg (fun e => e.trans insSumEquiv) h
+    simpa only [insPerm, Equiv.symm_trans_self, Equiv.trans_refl, Equiv.trans_assoc] using this
+  ext z
+  rcases z with k | j
+  · have := Equiv.congr_fun h' (Sum.inl k.succ)
+    rw [insHat_inl_succ, insHat_inl_succ] at this
+    have h2 := (Fin.succAbove_right_injective (p := x)) this
+    exact finSumFinEquiv.injective h2
+  · have := Equiv.congr_fun h' (Sum.inr j)
+    rw [insHat_inr, insHat_inr] at this
+    have h2 := (Fin.succAbove_right_injective (p := x)) this
+    exact finSumFinEquiv.injective h2
+
+/-- For fixed marked output `x`, the descended projection is injective on shuffle classes. -/
+theorem proj_left_injective (x : Fin (m + n + 1)) (σ₁ σ₂ : Equiv.Perm (Fin m ⊕ Fin n))
+    (h : Quotient.mk'' (insPerm x σ₁) =
+      (Quotient.mk'' (insPerm x σ₂) : Equiv.Perm.ModSumCongr (Fin (m + 1)) (Fin n))) :
+    (Quotient.mk'' σ₁ : Equiv.Perm.ModSumCongr (Fin m) (Fin n)) = Quotient.mk'' σ₂ := by
+  rw [Quotient.eq''] at h
+  rw [QuotientGroup.leftRel_apply] at h
+  obtain ⟨⟨sl, sr⟩, hsl⟩ := h
+  simp only [Equiv.Perm.sumCongrHom_apply] at hsl
+  -- `insPerm x σ₂ = insPerm x σ₁ * sumCongr sl sr`
+  have hmul : insPerm x σ₂ = insPerm x σ₁ * Equiv.sumCongr sl sr := by
+    rw [show Equiv.sumCongr sl sr = sl.sumCongr sr from rfl, hsl, mul_inv_cancel_left]
+  -- evaluating at `inl 0` forces `sl 0 = 0`
+  have hsl0 : sl 0 = 0 := by
+    have e2 : insSumEquiv (insPerm x σ₂ (Sum.inl 0)) = x := by
+      rw [insPerm, Equiv.trans_apply, Equiv.apply_symm_apply, insHat_inl_zero]
+    rw [hmul, Equiv.Perm.mul_apply, Equiv.sumCongr_apply, Sum.map_inl, insPerm,
+      Equiv.trans_apply, Equiv.apply_symm_apply] at e2
+    have : insHat x σ₁ (Sum.inl (sl 0)) = insHat x σ₁ (Sum.inl 0) := by
+      rw [e2, insHat_inl_zero]
+    exact Sum.inl_injective (insHat_injective x σ₁ this)
+  -- a permutation of `Fin (m+1)` fixing `0` factors through `decomposeFin`
+  set sl' := (Equiv.Perm.decomposeFin sl).2 with hsl'def
+  have hsl_eq : sl = Equiv.Perm.decomposeFin.symm (0, sl') := by
+    have hsplit : sl = Equiv.Perm.decomposeFin.symm (Equiv.Perm.decomposeFin sl) := by
+      rw [Equiv.symm_apply_apply]
+    have hp : (Equiv.Perm.decomposeFin sl).1 = 0 := by
+      have h0 : Equiv.Perm.decomposeFin.symm (Equiv.Perm.decomposeFin sl) 0 = sl 0 := by
+        rw [Equiv.symm_apply_apply]
+      rw [Equiv.Perm.decomposeFin_symm_apply_zero] at h0
+      rw [h0, hsl0]
+    rw [hsplit]; congr 1; rw [← hp]
+  rw [hsl_eq, ← insPerm_mul_sumCongr] at hmul
+  have := insPerm_left_injective x hmul
+  rw [Quotient.eq'', QuotientGroup.leftRel_apply]
+  exact ⟨(sl', sr), by simp only [Equiv.Perm.sumCongrHom_apply]; rw [this]; group⟩
+
+/-- The per-fibre identity: summing the left-hand side over the fibre of a fixed shuffle class
+`[τ]` reconstructs the `summand` of `uncurryFin Φ` at `[τ]`. -/
+theorem fibre_identity
+    (Φ : E →L[𝕜] (E [⋀^Fin m]→L[𝕜] (E [⋀^Fin n]→L[𝕜] G)))
+    (u : Fin (m + n + 1) → E) (τ : Equiv.Perm (Fin (m + 1) ⊕ Fin n)) :
+    ∑ p ∈ Finset.univ.filter
+        (fun p : Fin (m + n + 1) × Equiv.Perm.ModSumCongr (Fin m) (Fin n) =>
+          proj p = Quotient.mk'' τ),
+        (-1 : ℤ) ^ (p.1 : ℕ) • uncurrySum.summand (Φ (u p.1)) p.2
+          ((Fin.removeNth p.1 u) ∘ ⇑finSumFinEquiv)
+      = uncurrySum.summand (uncurryFin Φ) (Quotient.mk'' τ)
+          ((u ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv) := by
+  -- evaluate the right-hand summand, then `uncurryFin`
+  rw [summand_mk_eval, uncurryFin_apply]
+  have hw : ((u ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv)
+      = (u ∘ ⇑(insSumEquiv : Fin (m + 1) ⊕ Fin n ≃ Fin (m + n + 1))) := by
+    ext z; rfl
+  rw [hw, ContinuousAlternatingMap.sum_apply, Finset.smul_sum]
+  -- reindex the fibre sum on the left by `k ↦ (markedOut τ k, [restPerm τ k])`
+  refine (Finset.sum_bij'
+    (i := fun k _ => (markedOut τ k, Quotient.mk'' (restPerm τ k)))
+    (j := fun p _ => (τ.symm (insSumEquiv.symm p.1)).elim id (fun _ => 0))
+    (fun k _ => ?_) (fun p _ => Finset.mem_univ _) (fun k _ => ?_) (fun p hp => ?_)
+    (fun k _ => ?_)).symm
+  · -- membership in the fibre
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    rw [proj_mk, insPerm_markedOut_restPerm, Quotient.eq'', QuotientGroup.leftRel_apply]
+    refine ⟨(k.cycleRange, Equiv.refl (Fin n)), ?_⟩
+    simp only [Equiv.Perm.sumCongrHom_apply]
+    have hg : (τ * slotMove k)⁻¹ * τ = (slotMove k)⁻¹ := by group
+    rw [hg, slotMove_inv]
+  · -- right_inv: extractIdx (markedOut τ k) = k
+    show (τ.symm (insSumEquiv.symm (markedOut τ k))).elim id (fun _ => 0) = k
+    rw [markedOut, Equiv.symm_apply_apply, Equiv.symm_apply_apply, Sum.elim_inl, id]
+  · -- right_inv: `(markedOut τ i₀, [restPerm τ i₀]) = p` on the fibre
+    obtain ⟨x, c⟩ := p
+    induction c using Quotient.inductionOn' with
+    | _ σ =>
+      have hpe : proj (x, Quotient.mk'' σ) = Quotient.mk'' τ := by
+        have := (Finset.mem_filter.mp hp).2
+        exact this
+      rw [proj_mk] at hpe
+      have hpe2 : (insPerm x σ)⁻¹ * τ ∈ (Equiv.Perm.sumCongrHom (Fin (m + 1)) (Fin n)).range := by
+        rw [← QuotientGroup.leftRel_apply]; exact Quotient.exact' hpe
+      obtain ⟨⟨sl, sr⟩, hsl⟩ := hpe2
+      simp only [Equiv.Perm.sumCongrHom_apply] at hsl
+      -- `τ = insPerm x σ * sumCongr sl sr`
+      have hτ : τ = insPerm x σ * Equiv.sumCongr sl sr := by
+        rw [show Equiv.sumCongr sl sr = sl.sumCongr sr from rfl, hsl, mul_inv_cancel_left]
+      -- the marked slot index of `τ`
+      have hmark : τ (Sum.inl (sl⁻¹ 0)) = insSumEquiv.symm x := by
+        rw [hτ, Equiv.Perm.mul_apply, Equiv.sumCongr_apply, Sum.map_inl,
+          Equiv.Perm.apply_inv_self, insPerm, Equiv.trans_apply, insHat_inl_zero]
+      have hi0 : (τ.symm (insSumEquiv.symm x)).elim id (fun _ => 0) = sl⁻¹ 0 := by
+        rw [← hmark, Equiv.symm_apply_apply, Sum.elim_inl, id]
+      have hmx : markedOut τ (sl⁻¹ 0) = x := by rw [markedOut, hmark, Equiv.apply_symm_apply]
+      show ((fun k _ => (markedOut τ k, Quotient.mk'' (restPerm τ k)))
+        ((τ.symm (insSumEquiv.symm x)).elim id (fun _ => 0)) (Finset.mem_univ _)) = (x, _)
+      rw [hi0]
+      refine Prod.ext hmx ?_
+      show Quotient.mk'' (restPerm τ (sl⁻¹ 0)) = Quotient.mk'' σ
+      apply proj_left_injective (markedOut τ (sl⁻¹ 0))
+      have hclass : Quotient.mk'' (insPerm (markedOut τ (sl⁻¹ 0)) (restPerm τ (sl⁻¹ 0)))
+          = (Quotient.mk'' τ : Equiv.Perm.ModSumCongr (Fin (m + 1)) (Fin n)) := by
+        rw [insPerm_markedOut_restPerm, Quotient.eq'', QuotientGroup.leftRel_apply]
+        refine ⟨((sl⁻¹ 0).cycleRange, Equiv.refl (Fin n)), ?_⟩
+        simp only [Equiv.Perm.sumCongrHom_apply]
+        have hg : (τ * slotMove (sl⁻¹ 0))⁻¹ * τ = (slotMove (sl⁻¹ 0))⁻¹ := by group
+        rw [hg, slotMove_inv]
+      have hclass2 : Quotient.mk'' (insPerm (markedOut τ (sl⁻¹ 0)) σ)
+          = (Quotient.mk'' τ : Equiv.Perm.ModSumCongr (Fin (m + 1)) (Fin n)) := by
+        rw [hmx, Quotient.eq'', QuotientGroup.leftRel_apply]
+        exact ⟨(sl, sr), by rw [Equiv.Perm.sumCongrHom_apply, hτ]; group⟩
+      rw [hclass, ← hclass2]
+  · -- term identity at index `k`
+    simp only [ContinuousAlternatingMap.smul_apply]
+    rw [summand_mk_eval]
+    -- match the three arguments of `Φ`
+    have hlin : u (markedOut τ k) = (u ∘ ⇑insSumEquiv) (τ (Sum.inl k)) := by
+      rw [markedOut]; rfl
+    have hleft : (fun i => ((Fin.removeNth (markedOut τ k) u) ∘ ⇑finSumFinEquiv)
+          (restPerm τ k (Sum.inl i)))
+        = (Fin.removeNth k fun i => (u ∘ ⇑insSumEquiv) (τ (Sum.inl i))) := by
+      ext i
+      simp only [Function.comp_apply, Fin.removeNth]
+      rw [finSumFinEquiv_restPerm, succAbove_restHat]
+      simp only [Sum.map_inl, id]
+    have hright : (fun j => ((Fin.removeNth (markedOut τ k) u) ∘ ⇑finSumFinEquiv)
+          (restPerm τ k (Sum.inr j)))
+        = (fun j => (u ∘ ⇑insSumEquiv) (τ (Sum.inr j))) := by
+      ext j
+      simp only [Function.comp_apply, Fin.removeNth]
+      rw [finSumFinEquiv_restPerm, succAbove_restHat (z := Sum.inr j)]
+      simp only [Sum.map_inr, id]
+    rw [hlin, hleft, hright]
+    -- now equate the scalars via the sign identity (convert all `•` to `ℤ`-smul)
+    rw [Units.smul_def (Equiv.Perm.sign τ), Units.smul_def (Equiv.Perm.sign (restPerm τ k)),
+      smul_smul, smul_smul]
+    congr 1
+    have hs := sign_restPerm τ k
+    have hs' : ((-1 : ℤ)) ^ (markedOut τ k : ℕ) * (Equiv.Perm.sign (restPerm τ k) : ℤ)
+        = (Equiv.Perm.sign τ : ℤ) * (-1) ^ (k : ℕ) := by
+      have := congrArg (Units.val) hs
+      push_cast at this ⊢
+      linear_combination this
+    rw [← hs']
+
+theorem uncurryFin_uncurryFinAdd_left_aux
+    (Φ : E →L[𝕜] (E [⋀^Fin m]→L[𝕜] (E [⋀^Fin n]→L[𝕜] G)))
+    (u : Fin (m + n + 1) → E) :
+    ∑ x : Fin (m + n + 1), (-1) ^ (x : ℕ) • ∑ a : Equiv.Perm.ModSumCongr (Fin m) (Fin n),
+        uncurrySum.summand (Φ (u x)) a ((Fin.removeNth x u) ∘ ⇑finSumFinEquiv)
+      = ∑ a' : Equiv.Perm.ModSumCongr (Fin (m + 1)) (Fin n),
+        uncurrySum.summand (uncurryFin Φ) a' ((u ∘ ⇑finAddFlipAssoc) ∘ ⇑finSumFinEquiv) := by
+  classical
+  -- combine the double sum on the left into one sum over the product index set
+  have hcombine :
+      ∑ x : Fin (m + n + 1), (-1 : ℤ) ^ (x : ℕ) • ∑ a : Equiv.Perm.ModSumCongr (Fin m) (Fin n),
+          uncurrySum.summand (Φ (u x)) a ((Fin.removeNth x u) ∘ ⇑finSumFinEquiv)
+        = ∑ p : Fin (m + n + 1) × Equiv.Perm.ModSumCongr (Fin m) (Fin n),
+          (-1 : ℤ) ^ (p.1 : ℕ) • uncurrySum.summand (Φ (u p.1)) p.2
+            ((Fin.removeNth p.1 u) ∘ ⇑finSumFinEquiv) := by
+    rw [Fintype.sum_prod_type]
+    exact Finset.sum_congr rfl fun x _ => by rw [Finset.smul_sum]
+  rw [hcombine, ← Finset.sum_fiberwise Finset.univ proj
+    (fun p => (-1 : ℤ) ^ (p.1 : ℕ) • uncurrySum.summand (Φ (u p.1)) p.2
+      ((Fin.removeNth p.1 u) ∘ ⇑finSumFinEquiv))]
+  refine Finset.sum_congr rfl fun a' _ => ?_
+  induction a' using Quotient.inductionOn' with
+  | _ τ => exact fibre_identity Φ u τ
+
+/-- The abstract "uncurryFin commutes with uncurryFinAdd on the left factor" identity, with all the
+wedge/pairing data abstracted into an arbitrary curried family `Φ`. This is the combinatorial core
+of commutation lemma A: the value of `Ψ x` is the block-concatenation `uncurryFinAdd (Φ x)`, and
+uncurrying `Ψ` (prepending a derivative slot) equals uncurrying `Φ` in its left factor first and
+then block-concatenating, up to the index reshuffle `finAddFlipAssoc`. -/
+theorem uncurryFin_uncurryFinAdd_left
+    (Φ : E →L[𝕜] (E [⋀^Fin m]→L[𝕜] (E [⋀^Fin n]→L[𝕜] G)))
+    (Ψ : E →L[𝕜] (E [⋀^Fin (m + n)]→L[𝕜] G))
+    (hΨ : ∀ x, Ψ x = uncurryFinAdd (Φ x)) :
+    uncurryFin Ψ = domDomCongr finAddFlipAssoc (uncurryFinAdd (uncurryFin Φ)) := by
+  ext u
+  rw [uncurryFin_apply]
+  simp_rw [hΨ, uncurryFinAdd, domDomCongr_apply, uncurrySum_apply,
+    ContinuousMultilinearMap.sum_apply]
+  conv_rhs => erw [domDomCongr_apply, domDomCongr_apply, uncurrySum_apply,
+    ContinuousMultilinearMap.sum_apply]
+  exact uncurryFin_uncurryFinAdd_left_aux Φ u
+
+/-- **Commutation lemma A (left slot).** Uncurrying (prepending a derivative slot) commutes with
+wedging on the *left*: the new slot joins the `uncurryFin`-block, and the index reshuffling
+`finAddFlipAssoc` records that this block sits before `h`'s block. No sign appears. -/
+theorem uncurryFin_precompL_wedge (f : N →L[𝕜] N' →L[𝕜] N'')
+    (A : E →L[𝕜] (E [⋀^Fin m]→L[𝕜] N)) (h : E [⋀^Fin n]→L[𝕜] N') :
+    uncurryFin ((wedgeCLM (M := E) (m := m) (n := n) f).precompL E A h) =
+      domDomCongr finAddFlipAssoc (wedge_product (uncurryFin A) h f) := by
+  -- Abbreviate the fixed post-composition `L = ((compCAMCLM …).flip h).comp f`, so that
+  -- `f.compCAM₂ · h = L.compCAM ·`, and set `Φ x = L.compCAM (A x)`.
+  set L : N →L[𝕜] (E [⋀^Fin n]→L[𝕜] N'') :=
+    ((ContinuousLinearMap.compContinuousAlternatingMapCLM 𝕜 E N' N'').flip h).comp f with hL
+  set Φ : E →L[𝕜] (E [⋀^Fin m]→L[𝕜] (E [⋀^Fin n]→L[𝕜] N'')) :=
+    (ContinuousLinearMap.compContinuousAlternatingMapCLM 𝕜 E N (E [⋀^Fin n]→L[𝕜] N'') L).comp A
+    with hΦ
+  -- The RHS: rewrite `wedge_product (uncurryFin A) h f` as `uncurryFinAdd (uncurryFin Φ)`.
+  have hRHS : wedge_product (uncurryFin A) h f = uncurryFinAdd (uncurryFin Φ) := by
+    rw [wedge_product, compContinuousAlternatingMap₂_eq_comp, hΦ, ← hL,
+      uncurryFin_compContinuousAlternatingMapCLM]
+  -- The LHS: identify `(wedgeCLM f).precompL E A h` with a `Ψ` satisfying `Ψ x = uncurryFinAdd (Φ x)`.
+  rw [hRHS]
+  refine uncurryFin_uncurryFinAdd_left Φ _ (fun x => ?_)
+  simp only [ContinuousLinearMap.precompL_apply, wedgeCLM_apply]
+  rw [wedge_product, compContinuousAlternatingMap₂_eq_comp, hΦ, ← hL]
+  rfl
+
+theorem domDomCongr_domDomCongr {ι ι' ι'' : Type*} (σ : ι ≃ ι') (τ : ι' ≃ ι'')
+    (f : E [⋀^ι]→L[𝕜] G) :
+    domDomCongr τ (domDomCongr σ f) = domDomCongr (σ.trans τ) f := by
+  ext v; simp only [domDomCongr_apply, Function.comp_assoc, Equiv.coe_trans]
+
+theorem domDomCongr_smul {ι ι' : Type*} (σ : ι ≃ ι') (c : 𝕜) (f : E [⋀^ι]→L[𝕜] G) :
+    domDomCongr σ (c • f) = c • domDomCongr σ f := by
+  ext v; simp only [domDomCongr_apply, smul_apply]
+
+/-- Uncurrying intertwines with a scalar multiple of a (value-preserving) index recast: if
+`Ψ' v = c • domDomCongr (finCongr hd) (ψ' v)` for all `v`, then `uncurryFin Ψ'` is the same
+scalar multiple of the recast of `uncurryFin ψ'`. -/
+theorem uncurryFin_smul_domDomCongr {d d' : ℕ} (c : 𝕜) (hd : d = d')
+    (ψ' : E →L[𝕜] (E [⋀^Fin d]→L[𝕜] G)) (Ψ' : E →L[𝕜] (E [⋀^Fin d']→L[𝕜] G))
+    (hΨ : ∀ v, Ψ' v = c • domDomCongr (finCongr hd) (ψ' v)) :
+    uncurryFin Ψ' = c • domDomCongr (finCongr (by omega : d + 1 = d' + 1)) (uncurryFin ψ') := by
+  subst hd
+  have hΨ' : Ψ' = c • ψ' := by
+    ext v w
+    rw [hΨ]
+    simp only [finCongr_refl, domDomCongr_refl, ContinuousLinearMap.smul_apply, smul_apply]
+  rw [hΨ', uncurryFin_smul, finCongr_refl, domDomCongr_refl]
+
+/-- **Commutation lemma B (right slot).** Uncurrying commutes with wedging on the *right*: the new
+slot has to move past the `m` slots of `g`, producing the sign `(-1)^m`. -/
+theorem uncurryFin_precompR_wedge (f : N →L[𝕜] N' →L[𝕜] N'')
+    (g : E [⋀^Fin m]→L[𝕜] N) (C : E →L[𝕜] (E [⋀^Fin n]→L[𝕜] N')) :
+    uncurryFin ((wedgeCLM (M := E) (m := m) (n := n) f).precompR E g C) =
+      (-1 : 𝕜) ^ m • wedge_product g (uncurryFin C) f := by
+  -- `ψ v = wedge_product (C v) g f.flip`, the LEFT-factor wedge with the flipped pairing.
+  set ψ : E →L[𝕜] (E [⋀^Fin (n + m)]→L[𝕜] N'') :=
+    (wedgeCLM (M := E) (m := n) (n := m) f.flip).precompL E C g with hψ
+  -- Step 3: `(wedgeCLM f).precompR E g C = c • domDomCongr (finCongr _) ∘ ψ`, with c = (-1)^(m*n).
+  have hΨ : ∀ v, ((wedgeCLM (M := E) (m := m) (n := n) f).precompR E g C) v
+      = (-1 : 𝕜) ^ (m * n) • domDomCongr (finCongr (Nat.add_comm n m)) (ψ v) := by
+    intro v
+    simp only [ContinuousLinearMap.precompR_apply, ContinuousLinearMap.compL_apply,
+      ContinuousLinearMap.comp_apply, wedgeCLM_apply, hψ, ContinuousLinearMap.precompL_apply]
+    rw [wedge_flip g (C v) f]
+    ext w
+    rw [domDomCongr_apply, smul_apply, smul_apply, domDomCongr_apply]
+    rfl
+  rw [uncurryFin_smul_domDomCongr ((-1 : 𝕜) ^ (m * n)) (Nat.add_comm n m) ψ _ hΨ]
+  -- Step 4: `uncurryFin ψ` via Lemma A.
+  rw [hψ, uncurryFin_precompL_wedge f.flip C g]
+  -- Step 5: rewrite the goal RHS via `wedge_flip`.
+  rw [wedge_flip g (uncurryFin C) f]
+  rw [domDomCongr_domDomCongr, domDomCongr_smul]
+  -- combine the two scalars and the two index recasts
+  rw [smul_smul, ← pow_add]
+  -- the two composite recasts agree (all value-preserving `finCongr`s)
+  have heq : finAddFlipAssoc.trans (finCongr (show n + m + 1 = m + n + 1 from by omega))
+      = finAddCongr (m := n + 1) (n := m) := by
+    ext k
+    simp only [Equiv.coe_trans, Function.comp_apply, finAddFlipAssoc, finAddCongr, finCongr_apply,
+      Fin.coe_cast]
+  rw [heq]
+  congr 1
+  have h2 : (-1 : 𝕜) ^ (2 * m) = 1 := by
+    rw [pow_mul, neg_one_sq, one_pow]
+  rw [show m + m * (n + 1) = m * n + 2 * m by ring, pow_add, h2, mul_one]
+
+end commute
+
+end ContinuousAlternatingMap

--- a/DeRhamCohomology/DifferentialForm.lean
+++ b/DeRhamCohomology/DifferentialForm.lean
@@ -2,6 +2,7 @@ import Mathlib.Analysis.Calculus.FDeriv.Symmetric
 import DeRhamCohomology.ContinuousAlternatingMap.Curry
 import DeRhamCohomology.ContinuousAlternatingMap.FDeriv
 import DeRhamCohomology.ContinuousAlternatingMap.Wedge
+import DeRhamCohomology.ContinuousAlternatingMap.WedgeFDeriv
 import DeRhamCohomology.Equiv.Fin
 
 noncomputable section
@@ -360,20 +361,27 @@ theorem pullback_wedge (f : G → E) (ω₁ : Ω^m⟮E, F⟯) (ω₂ : Ω^n⟮E,
   simp only [Function.comp_apply, smul_left_cancel_iff]
   rfl
 
-/- The graded Leibniz rule for the exterior derivative of the wedge product -/
-theorem ederiv_wedge (ω : Ω^m⟮E, F⟯) (τ : Ω^n⟮E, F'⟯) (f : F →L[ℝ] F' →L[ℝ] F'') :
+/- The graded Leibniz rule for the exterior derivative of the wedge product.
+
+Note: the bare statement is false without differentiability assumptions (if `ω` is not
+differentiable at a point then `fderiv ℝ ω` is `0` there while `fderiv ℝ (ω ∧ τ)` need not be), so
+we add the (necessary) hypotheses `Differentiable ℝ ω` and `Differentiable ℝ τ`. -/
+theorem ederiv_wedge (ω : Ω^m⟮E, F⟯) (τ : Ω^n⟮E, F'⟯) (f : F →L[ℝ] F' →L[ℝ] F'')
+    (hω : Differentiable ℝ ω) (hτ : Differentiable ℝ τ) :
     ederiv (ω ∧[f] τ) = (domDomCongr finAddFlipAssoc (ederiv ω ∧[f] τ))
       + ((-1 : ℝ)^m) • ((ω ∧[f] ederiv τ)) := by
-  ext x y
-  rw[Pi.add_apply]
-  erw[ContinuousAlternatingMap.add_apply] -- FIXME
-  simp
-  rw[domDomCongr_apply, wedge_product_def, ContinuousAlternatingMap.wedge_product_def, uncurryFinAdd,
-    ContinuousAlternatingMap.domDomCongr_apply, uncurrySum_apply, wedge_product_def,
-    ContinuousAlternatingMap.wedge_product_def, uncurryFinAdd, ContinuousAlternatingMap.domDomCongr_apply,
-    uncurrySum_apply, ContinuousMultilinearMap.sum_apply, ContinuousMultilinearMap.sum_apply,
-    ederiv, uncurryFin_apply]
-  sorry
+  funext x
+  have key : fderiv ℝ (ω ∧[f] τ) x =
+      (ContinuousAlternatingMap.wedgeCLM (M := E) (m := m) (n := n) f).precompR E (ω x)
+          (fderiv ℝ τ x)
+        + (ContinuousAlternatingMap.wedgeCLM (M := E) (m := m) (n := n) f).precompL E (fderiv ℝ ω x)
+          (τ x) :=
+    ContinuousAlternatingMap.fderiv_wedge f (hω x) (hτ x)
+  show ContinuousAlternatingMap.uncurryFin (fderiv ℝ (ω ∧[f] τ) x) = _
+  rw [key, ContinuousAlternatingMap.uncurryFin_add,
+    ContinuousAlternatingMap.uncurryFin_precompR_wedge,
+    ContinuousAlternatingMap.uncurryFin_precompL_wedge, Pi.add_apply, Pi.smul_apply]
+  exact add_comm _ _
 
 /- The graded Leibniz rule for the interior product of the wedge product -/
 theorem iprod_wedge (ω : Ω^m + 1⟮E, F⟯) (τ : Ω^n + 1⟮E, F'⟯) (f : F →L[ℝ] F' →L[ℝ] F'') (v : E → E) :

--- a/DeRhamCohomology/DifferentialForm.lean
+++ b/DeRhamCohomology/DifferentialForm.lean
@@ -136,7 +136,7 @@ theorem ederivWithin_ederivWithin_apply (ω : Ω^n⟮E, F⟯) {s : Set E} {t : S
     have : DifferentiableWithinAt ℝ (fderivWithin ℝ ω s) s x := (h.fderivWithin_right hs le_rfl hx).differentiableWithinAt le_rfl
     exact (uncurryFinCLM.hasFDerivWithinAt.comp x this.hasFDerivWithinAt hst).fderivWithin (hs.uniqueDiffWithinAt hx)
   _ = 0 :=
-    uncurryFin_uncurryFinCLM_comp_of_symmetric <| h.isSymmSndFDerivWithinAt le_rfl hs hxx hx
+    uncurryFin_uncurryFinCLM_comp_of_symmetric <| h.isSymmSndFDerivWithinAt (by simp) hs hxx hx
 
 theorem ederivWithin_ederivWithin (ω : Ω^n⟮E, F⟯) {s : Set E} {t : Set (E →L[ℝ] E [⋀^Fin n]→L[ℝ] F)}
     (hst : MapsTo (fderivWithin ℝ ω s) s t) (h : ContDiffOn ℝ 2 ω s) (hs : UniqueDiffOn ℝ s) :
@@ -170,14 +170,12 @@ theorem ederiv_apply (ω : Ω^n⟮E, F⟯) {x : E} (hx : DifferentiableAt ℝ ω
     ContinuousAlternatingMap.fderiv_apply hx]
 
 theorem ederiv_ederiv_apply (ω : Ω^n⟮E, F⟯) {x} (h : ContDiffAt ℝ 2 ω x) :
-    ederiv (ederiv ω) x = 0 := calc
-  ederiv (ederiv ω) x = uncurryFin (fderiv ℝ (fun y ↦ uncurryFin (fderiv ℝ ω y)) x) := rfl
-  _ = uncurryFin (uncurryFinCLM.comp <| fderiv ℝ (fderiv ℝ ω) x) := by
-    congr 1
-    have : DifferentiableAt ℝ (fderiv ℝ ω) x := (h.fderiv_right le_rfl).differentiableAt le_rfl
-    exact (uncurryFinCLM.hasFDerivAt.comp x this.hasFDerivAt).fderiv
-  _ = 0 :=
-    uncurryFin_uncurryFinCLM_comp_of_symmetric <| h.isSymmSndFDerivAt le_rfl
+    ederiv (ederiv ω) x = 0 := by
+  -- Reduce to the `ederivWithin` version on `univ`, which avoids having to pin down the
+  -- normed-space instances of the intermediate `E →L[ℝ] E [⋀^Fin n]→L[ℝ] F` by hand.
+  have key := ederivWithin_ederivWithin_apply ω (s := univ) (t := univ)
+    (by simp) (mem_univ x) (mapsTo_univ _ _) h.contDiffWithinAt uniqueDiffOn_univ
+  simpa only [ederivWithin_univ] using key
 
 theorem ederiv_ederiv (ω : Ω^n⟮E, F⟯) (h : ContDiff ℝ 2 ω) : ederiv (ederiv ω) = 0 :=
   funext fun _ ↦ ederiv_ederiv_apply ω h.contDiffAt

--- a/DeRhamCohomology/DifferentialForm.lean
+++ b/DeRhamCohomology/DifferentialForm.lean
@@ -3,6 +3,7 @@ import DeRhamCohomology.ContinuousAlternatingMap.Curry
 import DeRhamCohomology.ContinuousAlternatingMap.FDeriv
 import DeRhamCohomology.ContinuousAlternatingMap.Wedge
 import DeRhamCohomology.ContinuousAlternatingMap.WedgeFDeriv
+import DeRhamCohomology.ContinuousAlternatingMap.WedgeAssoc
 import DeRhamCohomology.Equiv.Fin
 
 noncomputable section

--- a/DeRhamCohomology/DifferentialForm.lean
+++ b/DeRhamCohomology/DifferentialForm.lean
@@ -383,21 +383,17 @@ theorem ederiv_wedge (ω : Ω^m⟮E, F⟯) (τ : Ω^n⟮E, F'⟯) (f : F →L[�
     ContinuousAlternatingMap.uncurryFin_precompL_wedge, Pi.add_apply, Pi.smul_apply]
   exact add_comm _ _
 
-/- The graded Leibniz rule for the interior product of the wedge product -/
+/- The graded Leibniz rule for the interior product of the wedge product.
+
+Note: this is the antiderivation rule `ι_v (ω ∧ τ) = (ι_v ω) ∧ τ + (-1)^{deg ω} ω ∧ (ι_v τ)`.
+Since `deg ω = m + 1`, the sign is `(-1)^(m+1)` (the value-preserving `finAddFlipAssoc`
+relabellings carry no sign). -/
 theorem iprod_wedge (ω : Ω^m + 1⟮E, F⟯) (τ : Ω^n + 1⟮E, F'⟯) (f : F →L[ℝ] F' →L[ℝ] F'') (v : E → E) :
     iprod (domDomCongr finAddFlipAssoc (ω ∧[f] τ)) v = ((iprod ω v) ∧[f] τ)
-      + (-1)^m • (domDomCongr finAddFlipAssoc (ω ∧[f] (iprod τ v))) := by
-  ext e x
-  rw[_root_.add_apply]
-  erw[ContinuousAlternatingMap.add_apply] -- FIXME
-  simp only [Nat.add_eq, Int.reduceNeg, Pi.smul_apply, coe_smul]
-  rw[wedge_product_def, domDomCongr_apply, wedge_product_def, ContinuousAlternatingMap.wedge_product_def,
-    uncurryFinAdd, ContinuousAlternatingMap.domDomCongr_apply, uncurrySum_apply, ContinuousMultilinearMap.sum_apply,
-    ContinuousAlternatingMap.wedge_product_def, uncurryFinAdd, ContinuousAlternatingMap.domDomCongr_apply,
-    uncurrySum_apply, ContinuousMultilinearMap.sum_apply, iprod_apply, curryFin_apply, domDomCongr_apply,
-    wedge_product_def, ContinuousAlternatingMap.wedge_product_def, uncurryFinAdd,
-    ContinuousAlternatingMap.domDomCongr_apply, uncurrySum_apply, ContinuousMultilinearMap.sum_apply]
-  sorry
+      + ((-1 : ℝ))^(m + 1) • (domDomCongr finAddFlipAssoc (ω ∧[f] (iprod τ v))) := by
+  funext e
+  rw [Pi.add_apply, Pi.smul_apply]
+  exact ContinuousAlternatingMap.curryFin_wedge (ω e) (τ e) f (v e)
 
 /- Exterior derivative commutes with pullback -/
 theorem pullback_ederiv (f : E → F) (ω : Ω^n⟮F, G⟯) {x : E} (hf : ContDiffAt ℝ 2 f x)

--- a/DeRhamCohomology/Manifold/DifferentialForm.lean
+++ b/DeRhamCohomology/Manifold/DifferentialForm.lean
@@ -14,8 +14,15 @@ variable
   {EM : Type*} [NormedAddCommGroup EM] [NormedSpace ℝ EM]
   {HM : Type*} [TopologicalSpace HM]
   (IM : ModelWithCorners ℝ EM HM)
-  (M : Type*) [TopologicalSpace M] [ChartedSpace HM M] [SmoothManifoldWithCorners IM M]
+  (M : Type*) [TopologicalSpace M] [ChartedSpace HM M] [IsManifold IM ⊤ M]
   {m n : ℕ} {k l : ℕ∞}
+
+-- `TangentSpace IM x` is reducibly `EM`. Mathlib intentionally omits the normed-space instances on
+-- `TangentSpace` to keep type-class search from guessing them; here we record the ones agreeing with
+-- `EM`'s, so the instances inferred for `TangentSpace IM x` coincide with those used by
+-- `writtenInExtChartAt`/`iprod`/`wedge_product` (which see the underlying `EM`).
+local instance (x : M) : NormedAddCommGroup (TangentSpace IM x) := inferInstanceAs (NormedAddCommGroup EM)
+local instance (x : M) : NormedSpace ℝ (TangentSpace IM x) := inferInstanceAs (NormedSpace ℝ EM)
 
 -- Setup for Differential Form Space
 notation "Ω^" k "," m "⟮" EM "," IM "," M "⟯" =>
@@ -30,7 +37,7 @@ variable
   {EN : Type*} [NormedAddCommGroup EN] [NormedSpace ℝ EN]
   {HN : Type*} [TopologicalSpace HN]
   (IN : ModelWithCorners ℝ EN HN)
-  (N : Type*) [TopologicalSpace N] [ChartedSpace HN N] [SmoothManifoldWithCorners IN N]
+  (N : Type*) [TopologicalSpace N] [ChartedSpace HN N] [IsManifold IN ⊤ N]
 
 variable (α β : (x : N) → TangentSpace IN x [⋀^Fin m]→L[ℝ] Trivial N ℝ x)
 
@@ -65,7 +72,6 @@ section miprod
 
 variable
   [ChartedSpace (EM [⋀^Fin (m + 1)]→L[ℝ] ℝ) 𝒜⟮ℝ,Fin (m + 1);EM,TangentSpace IM;ℝ,Trivial M ℝ⟯]
-  [Π (x : M), NormedAddCommGroup (TangentSpace IM x)]
 
 def miprod (α : Ω^k,m + 1⟮EM, IM, M⟯) (V : Π (x : M), TangentSpace IM x) :
     (x : M) → TangentSpace IM x [⋀^Fin m]→L[ℝ] Trivial M ℝ x :=
@@ -81,7 +87,6 @@ section mwedge_product
 variable
   [ChartedSpace (EM [⋀^Fin m]→L[ℝ] ℝ) 𝒜⟮ℝ,Fin m;EM,TangentSpace IM;ℝ,Trivial M ℝ⟯] -- Shouldn't this just be true already?
   [ChartedSpace (EM [⋀^Fin n]→L[ℝ] ℝ) 𝒜⟮ℝ,Fin n;EM,TangentSpace IM;ℝ,Trivial M ℝ⟯] -- Shouldn't this just be true already?
-  [Π (x : M), NormedAddCommGroup (TangentSpace IM x)]
 
 /- Place for wedge product definitions -/
 def mwedge_product (α : Ω^k,m⟮EM, IM, M⟯) (β : Ω^l,n⟮EM, IM, M⟯) :

--- a/DeRhamCohomology/Manifold/VectorBundle/Alternating.lean
+++ b/DeRhamCohomology/Manifold/VectorBundle/Alternating.lean
@@ -23,11 +23,11 @@ variable {𝕜 ι B F₁ F₂ M : Type*} {E₁ : B → Type*} {E₂ : B → Type
   [∀ x, Module 𝕜 (E₂ x)]
   [NormedAddCommGroup F₂] [NormedSpace 𝕜 F₂]
   [TopologicalSpace (TotalSpace F₂ E₂)] [∀ x, TopologicalSpace (E₂ x)]
-  [∀ x, TopologicalAddGroup (E₂ x)] [∀ x, ContinuousSMul 𝕜 (E₂ x)]
+  [∀ x, IsTopologicalAddGroup (E₂ x)] [∀ x, ContinuousSMul 𝕜 (E₂ x)]
   {EM : Type*} [NormedAddCommGroup EM] [NormedSpace 𝕜 EM]
   {HM : Type*} [TopologicalSpace HM]
   {IM : ModelWithCorners 𝕜 EM HM}
-  [TopologicalSpace M] [ChartedSpace HM M] [SmoothManifoldWithCorners IM M] {n : ℕ∞}
+  [TopologicalSpace M] [ChartedSpace HM M] [IsManifold IM ⊤ M] {n : ℕ∞}
   [FiberBundle F₁ E₁] [VectorBundle 𝕜 F₁ E₁]
   [FiberBundle F₂ E₂] [VectorBundle 𝕜 F₂ E₂]
   {e₁ e₁' : Trivialization F₁ (π F₁ E₁)}
@@ -63,7 +63,7 @@ theorem _root_.ContinuousAlternatingMap.compContinuousLinearMapCLM_contMDiff :
   sorry
 
 theorem contMDiffOn_continuousAlternatingMapCoordChange
-    [SmoothVectorBundle F₁ E₁ IB] [SmoothVectorBundle F₂ E₂ IB]
+    [ContMDiffVectorBundle ⊤ F₁ E₁ IB] [ContMDiffVectorBundle ⊤ F₂ E₂ IB]
     [MemTrivializationAtlas e₁] [MemTrivializationAtlas e₁']
     [MemTrivializationAtlas e₂] [MemTrivializationAtlas e₂'] :
     ContMDiffOn IB 𝓘(𝕜, (F₁ [⋀^ι]→L[𝕜] F₂) →L[𝕜] F₁ [⋀^ι]→L[𝕜] F₂) ⊤
@@ -77,12 +77,12 @@ theorem contMDiffOn_continuousAlternatingMapCoordChange
       (s := e₂.baseSet ∩ e₂'.baseSet) (by mfld_set_tac))
   let s (q : (F₁ →L[𝕜] F₁) × (F₂ →L[𝕜] F₂)) :
       (F₁ →L[𝕜] F₁) × ((F₁ [⋀^ι]→L[𝕜] F₂) →L[𝕜] (F₁ [⋀^ι]→L[𝕜] F₂)) :=
-    (q.1, ContinuousLinearMap.compContinuousAlternatingMapL 𝕜 F₁ F₂ F₂ q.2)
+    (q.1, ContinuousLinearMap.compContinuousAlternatingMapCLM 𝕜 F₁ F₂ F₂ q.2)
   have hs : ContMDiff (𝓘(𝕜, (F₁ →L[𝕜] F₁)).prod 𝓘(𝕜, (F₂ →L[𝕜] F₂)))
       (𝓘(𝕜, (F₁ →L[𝕜] F₁)).prod 𝓘(𝕜, ((F₁ [⋀^ι]→L[𝕜] F₂) →L[𝕜] (F₁ [⋀^ι]→L[𝕜] F₂)))) ⊤ s := by
     let t (p : (F₁ →L[𝕜] F₁) × (F₂ →L[𝕜] F₂)) :
         ((F₁ [⋀^ι]→L[𝕜] F₂) →L[𝕜] (F₁ [⋀^ι]→L[𝕜] F₂)) :=
-      ContinuousLinearMap.compContinuousAlternatingMapL 𝕜 F₁ F₂ F₂ p.2
+      ContinuousLinearMap.compContinuousAlternatingMapCLM 𝕜 F₁ F₂ F₂ p.2
     have ht : ContMDiff (𝓘(𝕜, (F₁ →L[𝕜] F₁)).prod 𝓘(𝕜, (F₂ →L[𝕜] F₂)))
         𝓘(𝕜, ((F₁ [⋀^ι]→L[𝕜] F₂) →L[𝕜] (F₁ [⋀^ι]→L[𝕜] F₂))) ⊤ t := by
           refine ContMDiff.clm_apply ?hg ?hf
@@ -93,11 +93,11 @@ theorem contMDiffOn_continuousAlternatingMapCoordChange
     (𝕜 := 𝕜) (ι := ι) (F₁ := F₁) (F₂ := F₂)).comp contMDiff_fst)).comp hs).comp_contMDiffOn
     (s := (e₁.baseSet ∩ e₂.baseSet ∩ (e₁'.baseSet ∩ e₂'.baseSet))) h₁_prod_h₂
 
-variable [SmoothVectorBundle F₁ E₁ IB] [SmoothVectorBundle F₂ E₂ IB]
+variable [ContMDiffVectorBundle ⊤ F₁ E₁ IB] [ContMDiffVectorBundle ⊤ F₂ E₂ IB]
 
 instance Bundle.continuousAlternatingMap.vectorPrebundle.isSmooth :
-   (Bundle.continuousAlternatingMap.vectorPrebundle 𝕜 ι F₁ E₁ F₂ E₂).IsSmooth IB where
-  exists_smoothCoordChange := by
+   (Bundle.continuousAlternatingMap.vectorPrebundle 𝕜 ι F₁ E₁ F₂ E₂).IsContMDiff IB ⊤ where
+  exists_contMDiffCoordChange := by
     rintro _ ⟨e₁, e₂, he₁, he₂, rfl⟩ _ ⟨e₁', e₂', he₁', he₂', rfl⟩
     refine ⟨continuousAlternatingMapCoordChange 𝕜 ι e₁ e₁' e₂ e₂',
       contMDiffOn_continuousAlternatingMapCoordChange IB, ?_⟩
@@ -106,8 +106,8 @@ instance Bundle.continuousAlternatingMap.vectorPrebundle.isSmooth :
       exact hb
 
 instance SmoothVectorBundle.continuousAlternatingMap :
-    SmoothVectorBundle (F₁ [⋀^ι]→L[𝕜] F₂) (Bundle.continuousAlternatingMap 𝕜 ι F₁ E₁ F₂ E₂) IB :=
-  (Bundle.continuousAlternatingMap.vectorPrebundle 𝕜 ι F₁ E₁ F₂ E₂).smoothVectorBundle IB
+    ContMDiffVectorBundle ⊤ (F₁ [⋀^ι]→L[𝕜] F₂) (Bundle.continuousAlternatingMap 𝕜 ι F₁ E₁ F₂ E₂) IB :=
+  (Bundle.continuousAlternatingMap.vectorPrebundle 𝕜 ι F₁ E₁ F₂ E₂).contMDiffVectorBundle IB
 
 -- Notation for total space of continuous alternating bundle
 notation3 "𝒜⟮" 𝕜 "," ι ";"  F₁ "," E₁ ";"  F₂ "," E₂ "⟯" => Bundle.TotalSpace (F₁ [⋀^ι]→L[𝕜] F₂) ⋀^ι⟮𝕜; F₁, E₁; F₂, E₂⟯

--- a/DeRhamCohomology/Multilinear/Basic.lean
+++ b/DeRhamCohomology/Multilinear/Basic.lean
@@ -94,12 +94,20 @@ def flipMultilinear (f : ContinuousMultilinearMap 𝕜 (fun _ : ι ↦ M) (Conti
     { toFun := fun m =>
         MultilinearMap.mkContinuous
           { toFun := fun m' => f m' m
-            map_update_add' := sorry
-            map_update_smul' := sorry}
-          1 sorry
-      map_update_add' := sorry
-      map_update_smul' := sorry }
-    1 sorry
+            map_update_add' := fun m' i x y => by rw [f.map_update_add m' i x y]; rfl
+            map_update_smul' := fun m' i c x => by rw [f.map_update_smul m' i c x]; rfl }
+          (‖f‖ * ∏ j, ‖m j‖)
+          (fun m' => by
+            calc ‖f m' m‖ ≤ ‖f m'‖ * ∏ j, ‖m j‖ := (f m').le_opNorm m
+              _ ≤ (‖f‖ * ∏ i, ‖m' i‖) * ∏ j, ‖m j‖ := by gcongr; exact f.le_opNorm m'
+              _ = (‖f‖ * ∏ j, ‖m j‖) * ∏ i, ‖m' i‖ := by ring)
+      map_update_add' := fun m i x y => by ext m'; simp [(f m').map_update_add]
+      map_update_smul' := fun m i c x => by ext m'; simp [(f m').map_update_smul] }
+    ‖f‖
+    (fun m => ContinuousMultilinearMap.opNorm_le_bound (by positivity) fun m'' => by
+      calc ‖f m'' m‖ ≤ ‖f m''‖ * ∏ j, ‖m j‖ := (f m'').le_opNorm m
+        _ ≤ (‖f‖ * ∏ i, ‖m'' i‖) * ∏ j, ‖m j‖ := by gcongr; exact f.le_opNorm m''
+        _ = (‖f‖ * ∏ j, ‖m j‖) * ∏ i, ‖m'' i‖ := by ring)
 
 theorem flipMultilinear_apply (f : ContinuousMultilinearMap 𝕜 (fun _ : ι ↦ M)
     (ContinuousMultilinearMap 𝕜 (fun _ : ι' ↦ M') N)) (m : ι → M) (m' : ι' → M') :

--- a/DeRhamCohomology/Multilinear/Basic.lean
+++ b/DeRhamCohomology/Multilinear/Basic.lean
@@ -69,12 +69,23 @@ def LinearIsometryEquiv.flipMultilinear :
   left_inv := congrFun rfl
   right_inv := congrFun rfl
   norm_map' := fun f => by
-    simp
-    -- simp_rw[ContinuousLinearMap.flipMultilinear, MultilinearMap.mkContinuous, LinearMap.mkContinuous]
-    have h : ∀ m : ((i : ι) → E i), ∀ x : G, ‖f.flipMultilinear m x‖ = ‖f x m‖ := by
-      exact fun m x ↦ rfl
-    -- simp [apply_apply]
-    sorry
+    -- `‖f.flipMultilinear‖ = ‖f‖`: both directions follow from `‖f.flipMultilinear m x‖ = ‖f x m‖`
+    -- and the respective operator-norm bounds.
+    refine le_antisymm ?_ ?_
+    · refine ContinuousMultilinearMap.opNorm_le_bound (norm_nonneg f) fun m => ?_
+      refine ContinuousLinearMap.opNorm_le_bound _ (by positivity) fun x => ?_
+      calc ‖f.flipMultilinear m x‖ = ‖f x m‖ := rfl
+        _ ≤ ‖f x‖ * ∏ i, ‖m i‖ := (f x).le_opNorm m
+        _ ≤ (‖f‖ * ‖x‖) * ∏ i, ‖m i‖ := by gcongr; exact f.le_opNorm x
+        _ = (‖f‖ * ∏ i, ‖m i‖) * ‖x‖ := by ring
+    · show ‖f‖ ≤ ‖f.flipMultilinear‖
+      refine ContinuousLinearMap.opNorm_le_bound f (norm_nonneg f.flipMultilinear) fun x => ?_
+      refine ContinuousMultilinearMap.opNorm_le_bound (by positivity) fun m => ?_
+      calc ‖f x m‖ = ‖f.flipMultilinear m x‖ := rfl
+        _ ≤ ‖f.flipMultilinear m‖ * ‖x‖ := (f.flipMultilinear m).le_opNorm x
+        _ ≤ (‖f.flipMultilinear‖ * ∏ i, ‖m i‖) * ‖x‖ := by
+              gcongr; exact f.flipMultilinear.le_opNorm m
+        _ = (‖f.flipMultilinear‖ * ‖x‖) * ∏ i, ‖m i‖ := by ring
 
 namespace ContinuousMultilinearMap
 

--- a/DeRhamCohomology/VectorBundle/Alternating.lean
+++ b/DeRhamCohomology/VectorBundle/Alternating.lean
@@ -187,8 +187,10 @@ theorem continuousOn_continuousAlternatingMapCoordChange
   have h₄ := (continuousOn_coordChange 𝕜 e₂ e₂')
   let s (q : (F₁ →L[𝕜] F₁) × (F₂ →L[𝕜] F₂)) :
       (F₁ →L[𝕜] F₁) × ((F₁ [⋀^ι]→L[𝕜] F₂) →L[𝕜] (F₁ [⋀^ι]→L[𝕜] F₂)) :=
-    (q.1, ContinuousLinearMap.compContinuousAlternatingMapL 𝕜 F₁ F₂ F₂ q.2)
-  have hs : Continuous s := continuous_id.prodMap (ContinuousLinearMap.continuous _)
+    (q.1, ContinuousLinearMap.compContinuousAlternatingMapCLM 𝕜 F₁ F₂ F₂ q.2)
+  have hs : Continuous s :=
+    continuous_id.prodMap
+      (ContinuousLinearMap.continuous (ContinuousLinearMap.compContinuousAlternatingMapCLM 𝕜 F₁ F₂ F₂))
   -- note: the following `refine` worked in Lean 3; in Lean 4 this times out so has been replaced by
   -- the `have`/`exact` pair with an explicitly-provided `s` argument
   -- refine ((continuous_snd.clm_comp


### PR DESCRIPTION
## Summary

This change gets the differential-forms development compiling again against a
current `mathlib` (the manifest pins `mathlib4 @ b3c3864`) and proves a first
batch of the placeholder `sorry`s. After this change `lake build` succeeds
(exit 0); all modules produce `olean`s. The only remaining diagnostics are
`declaration uses 'sorry'` warnings for the results still listed under
**Remaining work** below.

Two logically separate threads are included:

1. **Mathlib API adaptations** — rename/refactor follow-through so the existing
   code elaborates against current `mathlib`.
2. **Proofs** — filling in the `flipAlternating`/`compContinuousAlternatingMap₂`
   family and `wedge_antisymm` (plus the `sumCongrPerm_spec` helper it needs).

`sorry` count dropped from **40 → 6** across the build-fix / first-batch commits;
follow-up commits prove the graded Leibniz rule `ederiv_wedge` (§3 below), the
interior-product Leibniz rule `iprod_wedge` (§4 below), and the **associativity of
the wedge product** `wedge_mul_assoc` (§5 below), leaving **3** open placeholder
tokens across 2 declarations (a further `sorry` in `Wedge.lean` is commented-out
dead code).

## 1. Mathlib API adaptations

These are pure follow-through for upstream renames/refactors; no mathematical
content changes.

- **`ContinuousLinearMap.compContinuousAlternatingMapL` → `…CLM`** — upstream
  renamed the bundled composition map.
  - `VectorBundle/Alternating.lean` (`continuousOn_…CoordChange`)
  - `Manifold/VectorBundle/Alternating.lean` (`contMDiffOn_…CoordChange`, twice)
- **`TopologicalAddGroup` → `IsTopologicalAddGroup`** (the `Is`-prefix refactor
  of topological-algebra classes) — `Manifold/VectorBundle/Alternating.lean`
  section variables.
- **`SmoothManifoldWithCorners I M` → `IsManifold I ⊤ M`** —
  `Manifold/VectorBundle/Alternating.lean`, `Manifold/DifferentialForm.lean`.
- **`SmoothVectorBundle` → `ContMDiffVectorBundle ⊤`** and the matching
  `VectorPrebundle` API:
  `.IsSmooth`→`.IsContMDiff … ⊤`, `exists_smoothCoordChange`→
  `exists_contMDiffCoordChange`, `.smoothVectorBundle`→`.contMDiffVectorBundle`.
  (`Manifold/VectorBundle/Alternating.lean`.)
- **Second-derivative symmetry now takes `minSmoothness`** — `isSymmSndFDeriv*`
  gained a `minSmoothness 𝕜 2 ≤ n` hypothesis; `le_rfl` no longer suffices.
  Discharged with `by simp` (`minSmoothness_of_isRCLikeNormedField` reduces
  `minSmoothness ℝ 2` to `2` for `ℝ`). (`DifferentialForm.lean`.)
- **`ederiv_ederiv_apply` reduced to the `ederivWithin` version on `univ`.**
  The previous direct `calc` broke under the bump because the intermediate
  `E →L[ℝ] E [⋀^Fin n]→L[ℝ] F` normed-space instances were left as
  metavariables during composition (`HasFDerivAt.comp` instance search got
  stuck). Routing through `ederivWithin_ederivWithin_apply … univ` +
  `ederivWithin_univ` avoids hand-pinning those instances and is a clean reuse.
  (`DifferentialForm.lean`.)
- **Explicit `NormedAddCommGroup`/`NormedSpace (TangentSpace IM x)` instances.**
  `TangentSpace IM x` is reducibly `EM`, but `mathlib` intentionally omits the
  normed-space instances on `TangentSpace`. We add them as `local instance`s
  agreeing with `EM`'s, so the instances inferred for `TangentSpace IM x`
  coincide with those used by `writtenInExtChartAt`/`iprod`/`wedge_product`.
  This also lets us drop the now-redundant
  `[Π x, NormedAddCommGroup (TangentSpace IM x)]` section hypotheses on
  `miprod`/`mwedge_product`. (`Manifold/DifferentialForm.lean`.)

## 2. Proofs completed (`sorry` → proof)

- **`Alternating/Basic.lean` (23 → 0 `sorry`s).** Filled in the bundled-structure
  obligations and operator-norm bounds (via `mkContinuous`) for:
  - `LinearIsometryEquiv.flipAlternating` (`invFun`, `left_inv`, `right_inv`,
    `norm_map'`),
  - `ContinuousLinearMap.compContinuousAlternatingMap₂`
    (`map_update_add'/smul'`, `cont`, `map_eq_zero_of_eq'`),
  - `ContinuousMultilinearMap.flipAlternating` and
    `ContinuousAlternatingMap.flipAlternating`.
- **`ContinuousAlternatingMap/Wedge.lean` (live `sorry`s 4 → 1).**
  - `sumCongrPerm_spec` — the quotient/`leftRel` compatibility lemma.
  - `wedge_antisymm` — antisymmetry of the multiplication wedge product
    (the thesis's Prop. 4.26), which previously rested on the above `sorry`.
- **`Multilinear/Basic.lean` — now fully `sorry`-free** *(follow-up commits
  `34e1869`, `0115071`).*
  - `ContinuousMultilinearMap.flipMultilinear` (6 → 0): ported from the sibling
    `ContinuousMultilinearMap.flipAlternating` (multilinearity + operator-norm
    bounds), correcting its placeholder norm bounds (`1` → `‖f‖`). On the wedge
    critical path (used by `uncurrySum.summand`).
  - `LinearIsometryEquiv.flipMultilinear`'s `norm_map'` (`‖f.flipMultilinear‖ = ‖f‖`):
    `le_antisymm` of two operator-norm bounds (`opNorm_le_bound`), via
    `‖f.flipMultilinear m x‖ = ‖f x m‖` + `le_opNorm`.

## Corrected `Fin`-symmetry helper (`finSumCongr`)

Completing `wedge_antisymm` required fixing one auxiliary `Equiv`. **This is a
definition correction, not a theorem that was false** — the original `finSumCongr`
was a valid bijection but the *wrong permutation for its role*, which is why the
proofs built on it (`sumCongrPerm_spec`) could not close.

- `finSumCongr : Fin m ⊕ Fin n ≃ Fin n ⊕ Fin m` previously unfolded to the
  block-rotation `finSumFinEquiv.trans (finAddCongr.trans finSumFinEquiv.symm)`.
  As the relabelling underlying `sumCongrPerm` this is wrong: it does **not** send
  the `Fin m` block to the `Fin m` block, which is what blocked `sumCongrPerm_spec`
  (its two `sorry`s).
- It is now the plain summand swap `Equiv.sumComm (Fin m) (Fin n)`. The old
  block-rotation expression is preserved under the new name `finSumAddCongr` and
  is used (via `sumRotatePerm`, of sign `(-1)^(m*n)`) precisely where that sign is
  needed in the reindexing `wedgeFlipEquiv`.

Scope: this supports the **antisymmetry** proof (`wedge_antisymm`). It does **not**
touch associativity — `wedge_mul_assoc` is still `sorry` (see Remaining work) and
uses a separate `finAssoc`/`addAssocPerm` chain.

## 3. Graded Leibniz rule for the exterior derivative (`ederiv_wedge`)

*(follow-up commit)* Proves `ederiv_wedge` — the graded Leibniz / antiderivation
rule for `d` (thesis §5.2.1):

```
ederiv (ω ∧[f] τ) = domDomCongr finAddFlipAssoc (ederiv ω ∧[f] τ)
                      + (-1)^m • (ω ∧[f] ederiv τ)
```

Verified end-to-end `sorry`-free: `#print axioms ederiv_wedge` reports only
`[propext, Classical.choice, Quot.sound]`. We add the (mathematically necessary)
hypotheses `Differentiable ℝ ω`, `Differentiable ℝ τ` — the bare statement is
false at points of non-differentiability.

All new infrastructure lives in the new file
`ContinuousAlternatingMap/WedgeFDeriv.lean`:

- **Calculus.** `wedgeCLM` bundles the wedge as a bounded *bilinear* map
  (`LinearMap.mkContinuous₂` + an operator-norm bound `norm_wedge_le`), and
  `fderiv_wedge` is the Fréchet product rule for `x ↦ ω x ∧[f] τ x`, obtained via
  `ContinuousLinearMap.fderiv_of_bilinear`. (This routing is essential: it
  differentiates the `ContinuousAlternatingMap`-valued `p ↦ wedgeCLM f p.1 p.2`,
  sidestepping a normed-instance diamond that blocks `HasFDerivAt.clm_apply` on
  `CLM`-of-`ContinuousAlternatingMap` value spaces.)
- **Combinatorial core** — the two commutation lemmas relating `uncurryFin` (the
  building block of `d`) to the wedge:
  - `uncurryFin_precompL_wedge` (left slot, no sign, `finAddFlipAssoc` reindex) —
    reduced to the abstract `uncurryFin_uncurryFinAdd_left` and proved by an
    explicit **slot-insertion fibration** over the `Equiv.Perm.ModSumCongr`
    shuffle quotient: a `Fin.cycleRange`-based insertion permutation
    (`insPerm`/`proj`, with cyclic sign from `Fin.sign_cycleRange`), fibre
    enumeration, and `Finset.sum_bij'` / `Finset.sum_fiberwise`. This is the same
    quotient-combinatorics family as the still-open `wedge_mul_assoc`.
  - `uncurryFin_precompR_wedge` (right slot, sign `(-1)^m`) — reduced to the left
    case via the new general-`f` antisymmetry `wedge_flip` (added to `Wedge.lean`,
    generalising `wedge_antisymm` from the scalar pairing to an arbitrary `f`)
    plus the `uncurryFin_smul_domDomCongr` helper, avoiding a second fibration.

`ederiv_wedge` itself is then a short assembly: `fderiv_wedge` + `uncurryFin_add`
+ the two commutation lemmas (`DifferentialForm.lean`).

## 4. Graded Leibniz rule for the interior product (`iprod_wedge`)

*(follow-up commit)* Proves `iprod_wedge` — the antiderivation rule for the
interior product `ι_v` (thesis §5.2.1). Verified end-to-end `sorry`-free:
`#print axioms iprod_wedge` reports only `[propext, Classical.choice, Quot.sound]`.

### ⚠ Sign correction (the placeholder statement was off by one sign)

The original `sorry` statement carried coefficient `(-1)^m`. **That statement is
false**; the correct coefficient is **`(-1)^(m+1)`**, and the statement has been
amended accordingly:

```
iprod (domDomCongr finAddFlipAssoc (ω ∧[f] τ)) v
  = (iprod ω v ∧[f] τ)
    + (-1 : ℝ)^(m+1) • domDomCongr finAddFlipAssoc (ω ∧[f] iprod τ v)
```

(here `ω : Ω^(m+1)`, `τ : Ω^(n+1)`).

**Informal reasoning.** The interior product `ι_v` is an *antiderivation of degree
−1* on the exterior algebra: for a homogeneous form `α` of degree `p`,

```
ι_v (α ∧ β) = (ι_v α) ∧ β  +  (−1)^p · α ∧ (ι_v β).
```

In this statement `α = ω` has degree `deg ω = m + 1`, so the sign on the second
term is `(−1)^(m+1)`, **not** `(−1)^m`. The two `domDomCongr finAddFlipAssoc`
relabellings are value-preserving `finCongr` casts (degree bookkeeping only:
`(m+1)+(n+1)` is reassociated so the contracted slot lands at position `0` and the
result has degree `m+(n+1)`); being `Fin.cast`s they reorder no arguments and
therefore contribute **no** sign of their own. Hence the only sign is the Koszul
`(−1)^{deg ω}` from moving `ι_v` past `ω`.

**Sanity check at `m = n = 0`** (where both reindexings are trivial, so no sign can
hide in them): for `1`-forms `g, h`, the wedge is
`(g ∧ h)(u₀,u₁) = f(g u₀)(h u₁) − f(g u₁)(h u₀)`, so contracting slot `0` with `x₀`
gives `(g x₀)·(h z) − (g z)·(h x₀)`. Matching this against
`(ι_{x₀} g)∧h + c · g∧(ι_{x₀} h) = (g x₀)(h z) + c·(g z)(h x₀)` forces `c = −1`,
i.e. `(−1)^(m+1) = (−1)^1`, contradicting `(−1)^m = (−1)^0 = +1`. The mechanised
proof independently produces `(−1)^(m+1)` from the shuffle-sign combinatorics
(`sign(insPermR b) = (−1)^(m+1)·sign b`, see below), and a proof of the `(−1)^m`
form is impossible.

**Reference.** The antiderivation identity with the `(−1)^{deg α}` sign is standard;
see e.g. the article *Interior product* (Wikipedia), which states it in exactly this
form, or J. M. Lee, *Introduction to Smooth Manifolds*, 2nd ed. (GTM 218), §14
(interior multiplication), where `ι_v` is shown to be an antiderivation of degree −1.
(Equivalently Bott–Tu, *Differential Forms in Algebraic Topology*, or Warner,
*Foundations of Differentiable Manifolds and Lie Groups*.)

### Proof structure (all new lemmas in `ContinuousAlternatingMap/WedgeFDeriv.lean`)

- **CAM-level core `curryFin_wedge`.** `iprod` is `curryFin` (prepend `v e` at slot
  `0`) pointwise, so `iprod_wedge` lifts in two lines from a continuous-alternating-map
  identity:
  ```
  curryFin (domDomCongr finAddFlipAssoc (g ∧[f] h)) x₀
    = (curryFin g x₀) ∧[f] h
      + (-1)^(m+1) • domDomCongr finAddFlipAssoc (g ∧[f] curryFin h x₀)
  ```
- **The combinatorics.** Both sides expand to shuffle sums over
  `Equiv.Perm.ModSumCongr (Fin (m+1)) (Fin (n+1))`; the sum is split by `isLeftClass`
  — whether the contracted slot `0` feeds into the left (`g`) or right (`h`) factor —
  via `Finset.sum_filter_add_sum_filter_not`.
  - **Left part** reuses the *existing* `ederiv_wedge` slot-insertion machinery
    (`insPerm 0`, `proj`, `restPerm`, `sign_insPerm_zero`); here the bijection onto
    the left classes is exact (fibre size 1), simpler than `ederiv`'s fibration.
  - **Right part** required a new right-block-insertion mirror `insPermR` with its
    own descent (`projR`, `projR_spec`), injectivity (`projR_left_injective`),
    surjectivity (`restPermR`, `insPermR_restPermR`), and sign
    `sign (insPermR b) = (−1)^(m+1) · sign b` — the latter via
    `insPermR b = insPermR 1 * liftR b` and `sign (insPermR 1) = (−1)^(m+1)` proved
    by conjugating to `Fin.cycleRange ⟨m+1⟩` (`Fin.sign_cycleRange`).

## 5. Associativity of the wedge product (`wedge_mul_assoc`)

*(follow-up commit)* Proves `wedge_mul_assoc` — associativity of the
multiplication wedge product (thesis Prop. 4.27),

```
domDomCongr finAssoc.symm (g ∧[𝕜] h ∧[𝕜] l) = (g ∧[𝕜] h) ∧[𝕜] l
```

Verified end-to-end `sorry`-free: `#print axioms wedge_mul_assoc` reports only
`[propext, Classical.choice, Quot.sound]`.

### File placement

The proof lives in the **new file** `ContinuousAlternatingMap/WedgeAssoc.lean`, not
in `Wedge.lean`, because it reuses `summand_mk_eval` and `domDomCongr_domDomCongr`
from `WedgeFDeriv.lean`, and `Wedge.lean` cannot import `WedgeFDeriv` (that would be
an import cycle). The placeholder `wedge_mul_assoc` was removed from `Wedge.lean`;
the theorem keeps its fully-qualified name `ContinuousAlternatingMap.wedge_mul_assoc`
and its exact statement, so its one downstream user (`DifferentialForm.lean`, in the
`mwedge`-associativity corollary) is unaffected apart from an added `import`.

### Proof strategy

The naive approach — a direct bijection between the two nested shuffle index sets
`ModSumCongr (Fin m) (Fin (n+p)) × ModSumCongr (Fin n) (Fin p)` and
`ModSumCongr (Fin (m+n)) (Fin p) × ModSumCongr (Fin m) (Fin n)` — **provably does not
descend to the quotients** (the outer quotient quotients by all of `S_{n+p}`,
destroying the `n`/`p` split the inner factor records). The relation between this
repo's `uncurrySum`-based wedge and `AlternatingMap.domCoprod` was also considered,
but Mathlib has no `domCoprod` associativity, so it would not save the combinatorial
core. Instead:

- **Triple Young quotient.** Both bracketings are shown equal to a single sum over
  `T ι κ μ := Equiv.Perm (ι ⊕ κ ⊕ μ) ⧸ (youngHom).range`, the permutations of three
  blocks modulo block-diagonal relabelling, with summand `tterm A = sign A •
  g(v∘A∘inl)·h(v∘A∘inr∘inl)·l(v∘A∘inr∘inr)` (well-defined on the quotient because the
  alternating maps absorb the within-block signs).
- **Two fibrations, not a product section.** `lcore_eq_sumT` (resp. `rcore_eq_sumT`)
  expresses each bracketing as `∑_{q : T} tterm q` via `Finset.sum_fiberwise` over a
  genuine quotient projection `T → ModSumCongr (·) (·)`, with a per-fibre
  `Finset.sum_bij`. These per-fibre bijections are clean: no `(−1)^k`, no
  `Fin.cycleRange`, no `Fin` arithmetic — only `sumCongr`/`permCongr`/`sign`
  multiplicativity.
- **Abstract core.** The combinatorial heart `core_assoc` is stated and proved over
  arbitrary `Sum` index types `ι κ μ` (zero `Fin` noise). It is connected to the
  `Fin`-indexed wedge by two `pullout` lemmas — `uncurrySum (mul.compCAM₂ g
  (domDomCongr e X)) = domDomCongr (sumCongr 1 e) (uncurrySum (mul.compCAM₂ g X))`
  and its left mirror — which move the `finSumFinEquiv` reindexings (coming from
  `uncurryFinAdd = domDomCongr finSumFinEquiv ∘ uncurrySum`) out of the wedge
  factors. The `pullout` lemmas go through `Fintype.sum_equiv (mscCongr eL eR)`, where
  `mscCongr` descends `(sumCongr eL eR).permCongr` to a `ModSumCongr ≃ ModSumCongr`.
- **Reconciliation.** The value-preserving index recasts satisfy `eR3 = sumAssoc.trans
  eL3` (`eR3_eq_sumAssoc_eL3`, by `Fin.ext`); the final assembly is `pullout_right`/
  `pullout_left` + `domDomCongr_domDomCongr` + `core_assoc` + that recast identity.

Supporting general-purpose lemmas added (Mathlib lacks them): `permCongr_mul`,
`permCongr_one`, `permCongr_inv`, `permCongr_symm_permCongr`, `permCongr_permCongr_symm`,
and the `sumAssoc`-conjugation-of-Young identities `permCongr_sumAssoc_young` /
`permCongr_sumAssoc_symm_young`.

One reviewer-relevant subtlety: for the custom quotient `T` (and `ModSumCongr` over a
compound index `κ ⊕ μ`), `Fintype`/`DecidableEq`/`DecidablePred` do not auto-synthesize;
they are supplied by explicit `DecidablePred (· ∈ (sumCongrHom …).range)` instances (the
lambda-eta trick from `Equiv.Perm.sumCongrHom.decidableMemRange`). `open Classical` is
deliberately avoided — it would introduce a second `Fintype (ModSumCongr …)` that
diamonds against Mathlib's canonical instance and breaks `Finset.sum_congr rfl`.

## Remaining work (follow-up PRs)

3 open `sorry`s remain across 2 declarations. None block the build; grouped by file
(`Multilinear/Basic.lean`, the `ederiv`/`iprod` Leibniz rules, and wedge associativity
are now cleared):

- **`DifferentialForm.lean` (2)** — `pullback_ederiv` (two differentiability
  side-goals; `d` commutes with pullback). Hardest; needs the varying-argument
  product rule / pre-composition derivative infrastructure.
- **`Manifold/VectorBundle/Alternating.lean` (1)** —
  `compContinuousLinearMapCLM_contMDiff` (smoothness of pre-composition with a
  continuous linear map; pending the corresponding `mathlib` result, as noted in
  the thesis under Thm. 4.32).

## Verification

```
lake exe cache get   # mathlib oleans (manifest @ b3c3864)
lake build           # exit 0; all modules built; only `sorry` warnings remain
                     #   (the 2 declarations under Remaining work)
#print axioms ederiv_wedge      # [propext, Classical.choice, Quot.sound] — no sorryAx
#print axioms iprod_wedge       # [propext, Classical.choice, Quot.sound] — no sorryAx
#print axioms wedge_mul_assoc   # [propext, Classical.choice, Quot.sound] — no sorryAx
```